### PR TITLE
Add housekeeping MVP

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -539,3 +539,20 @@ model BookingAddOn {
   booking Booking @relation(fields: [booking_id], references: [id], onDelete: Cascade)
   addOn   AddOn   @relation(fields: [addon_id], references: [id], onDelete: Restrict)
 }
+
+model MaintenanceTask {
+  id          Int      @id @default(autoincrement())
+  title       String   @db.VarChar(255)
+  description String?
+  status      String   @default("PENDING")
+  due_date    DateTime?
+  room_id     Int?
+  location_id Int
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @default(now()) @updatedAt
+
+  rooms     Room?    @relation(fields: [room_id], references: [id], onUpdate: NoAction, onDelete: SetNull)
+  locations Location @relation(fields: [location_id], references: [id], onUpdate: NoAction)
+
+  @@map("maintenance_tasks")
+}

--- a/src/app/(internal)/(dashboard_layout)/maintenance/content.tsx
+++ b/src/app/(internal)/(dashboard_layout)/maintenance/content.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import {createColumnHelper} from "@tanstack/react-table";
+import React, {useState} from "react";
+import {formatToDateTime} from "@/app/_lib/util";
+import {TableContent} from "@/app/_components/pageContent/TableContent";
+import {useHeader} from "@/app/_context/HeaderContext";
+import Link from "next/link";
+import {MaintenanceForm} from "@/app/(internal)/(dashboard_layout)/maintenance/form";
+import {MaintenanceTaskInclude} from "@/app/(internal)/(dashboard_layout)/maintenance/maintenance-action";
+import {deleteMaintenanceTaskAction, upsertMaintenanceTaskAction} from "@/app/(internal)/(dashboard_layout)/maintenance/maintenance-action";
+
+export interface MaintenanceContentProps {
+  tasks: MaintenanceTaskInclude[];
+}
+
+export default function MaintenanceContent({tasks}: MaintenanceContentProps) {
+  const headerContext = useHeader();
+  const [dataState, setDataState] = useState<typeof tasks>(tasks);
+
+  const columnHelper = createColumnHelper<typeof tasks[0]>();
+  const columns = [
+    columnHelper.accessor(row => row.id, { header: "ID", size: 20 }),
+    columnHelper.accessor(row => row.title, { header: "Judul" }),
+    columnHelper.accessor(row => row.status, { header: "Status" }),
+    columnHelper.accessor(row => row.due_date ? formatToDateTime(new Date(row.due_date), false) : "-", { header: "Jatuh Tempo" }),
+    columnHelper.accessor(row => row.rooms?.room_number, { header: "Kamar" }),
+    columnHelper.accessor(row => row.locations?.name, { header: "Lokasi" }),
+    columnHelper.accessor(row => formatToDateTime(row.createdAt), { header: "Dibuat" }),
+  ];
+
+  if (!headerContext.locationID) {
+    // if multi-location view, show location column maybe; already included
+  }
+
+  return (
+    <TableContent<typeof tasks[0]>
+      name="Tugas"
+      initialContents={dataState}
+      columns={columns}
+      form={
+        // @ts-ignore
+        <MaintenanceForm/>
+      }
+      searchPlaceholder="Cari tugas"
+      upsert={{
+        // @ts-ignore
+        mutationFn: upsertMaintenanceTaskAction,
+      }}
+      delete={{
+        // @ts-ignore
+        mutationFn: deleteMaintenanceTaskAction,
+      }}
+    />
+  );
+}

--- a/src/app/(internal)/(dashboard_layout)/maintenance/form.tsx
+++ b/src/app/(internal)/(dashboard_layout)/maintenance/form.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import {TableFormProps} from "@/app/_components/pageContent/TableContent";
+import {MaintenanceTask} from "@prisma/client";
+import React, {useEffect, useState} from "react";
+import {Button, Input, Textarea, Select, Option, Typography} from "@material-tailwind/react";
+import {ZodFormattedError} from "zod";
+
+interface MaintenanceFormProps extends TableFormProps<MaintenanceTask> {}
+
+const statusOptions = [
+  { value: "PENDING", label: "Pending" },
+  { value: "IN_PROGRESS", label: "In Progress" },
+  { value: "COMPLETED", label: "Completed" },
+];
+
+export function MaintenanceForm(props: MaintenanceFormProps) {
+  const [taskData, setTaskData] = useState<Partial<MaintenanceTask>>(props.contentData ?? {});
+  const [fieldErrors, setFieldErrors] = useState<ZodFormattedError<MaintenanceTask> | undefined>(props.mutationResponse?.errors);
+
+  useEffect(() => {
+    setFieldErrors(props.mutationResponse?.errors);
+  }, [props.mutationResponse?.errors]);
+
+  return (
+    <div className="w-full px-8 py-4">
+      <h1 className="text-xl font-semibold text-black">{(props.contentData && props.contentData.id) ? "Perubahan" : "Pembuatan"} Tugas</h1>
+      <div className="mt-4">
+        <div className="mb-1 flex flex-col gap-6">
+          {taskData.id && (
+            <div>
+              <label htmlFor="id">
+                <Typography variant="h6" color="blue-gray">ID</Typography>
+              </label>
+              <Input disabled variant="outlined" value={taskData.id} size="lg" labelProps={{className: "before:content-none after:content-none"}} />
+            </div>
+          )}
+          <div>
+            <label htmlFor="title">
+              <Typography variant="h6" color="blue-gray">Judul</Typography>
+            </label>
+            <Input variant="outlined" value={taskData.title ?? ""} onChange={e => setTaskData(p => ({...p, title: e.target.value}))} size="lg" error={!!fieldErrors?.title} className={`${fieldErrors?.title ? "!border-t-red-500" : "!border-t-blue-gray-200 focus:!border-t-gray-900"}`} labelProps={{className: "before:content-none after:content-none"}} />
+          </div>
+          <div>
+            <label htmlFor="description">
+              <Typography variant="h6" color="blue-gray">Deskripsi</Typography>
+            </label>
+            <Textarea value={taskData.description ?? ""} onChange={e => setTaskData(p => ({...p, description: e.target.value}))} labelProps={{className: "before:content-none after:content-none"}} />
+          </div>
+          <div>
+            <label htmlFor="status">
+              <Typography variant="h6" color="blue-gray">Status</Typography>
+            </label>
+            <Select value={taskData.status ?? "PENDING"} onChange={val => setTaskData(p => ({...p, status: val!}))}>
+              {statusOptions.map(opt => <Option key={opt.value} value={opt.value}>{opt.label}</Option>)}
+            </Select>
+          </div>
+          <div>
+            <label htmlFor="due_date">
+              <Typography variant="h6" color="blue-gray">Tanggal Jatuh Tempo</Typography>
+            </label>
+            <Input type="date" value={taskData.due_date ? new Date(taskData.due_date).toISOString().split('T')[0] : ''} onChange={e => setTaskData(p => ({...p, due_date: new Date(e.target.value)}))} variant="outlined" size="lg" labelProps={{className: "before:content-none after:content-none"}} />
+          </div>
+          <div>
+            <label htmlFor="room_id">
+              <Typography variant="h6" color="blue-gray">ID Kamar (Opsional)</Typography>
+            </label>
+            <Input type="number" value={taskData.room_id ?? ''} onChange={e => setTaskData(p => ({...p, room_id: e.target.value ? Number(e.target.value) : undefined}))} variant="outlined" size="lg" labelProps={{className: "before:content-none after:content-none"}} />
+          </div>
+          <div>
+            <label htmlFor="location_id">
+              <Typography variant="h6" color="blue-gray">ID Lokasi</Typography>
+            </label>
+            <Input type="number" value={taskData.location_id ?? ''} onChange={e => setTaskData(p => ({...p, location_id: Number(e.target.value)}))} variant="outlined" size="lg" labelProps={{className: "before:content-none after:content-none"}} />
+          </div>
+          {props.mutationResponse?.failure && (
+            <Typography variant="h6" color="red" className="-mb-4">{props.mutationResponse.failure}</Typography>
+          )}
+        </div>
+        <div className="flex gap-x-4 justify-end">
+          <Button onClick={() => props.setDialogOpen(false)} variant="outlined" className="mt-6">Batal</Button>
+          <Button onClick={() => props.mutation.mutate(taskData)} color="blue" className="mt-6" loading={props.mutation.isPending}>{(props.contentData && props.contentData.id) ? "Ubah" : "Buat"}</Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(internal)/(dashboard_layout)/maintenance/maintenance-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/maintenance/maintenance-action.ts
@@ -1,0 +1,58 @@
+"use server";
+
+import {PrismaClientKnownRequestError, PrismaClientUnknownRequestError} from "@prisma/client/runtime/library";
+import {maintenanceTaskSchema, maintenanceTaskSchemaWithID} from "@/app/_lib/zod/maintenance/zod";
+import {createMaintenanceTask, deleteMaintenanceTask, updateMaintenanceTaskByID, MaintenanceTask, getMaintenanceTasks} from "@/app/_db/maintenance";
+import {GenericActionsType} from "@/app/_lib/actions";
+
+export type MaintenanceTaskInclude = MaintenanceTask & {
+  rooms?: { id: number; room_number: string } | null;
+  locations?: { id: number; name: string } | null;
+};
+
+export async function upsertMaintenanceTaskAction(task: Partial<MaintenanceTask>): Promise<GenericActionsType<MaintenanceTaskInclude>> {
+  const { success, data, error } = maintenanceTaskSchema.partial({ id: true }).safeParse(task);
+
+  if (!success) {
+    return { errors: error?.format() };
+  }
+
+  try {
+    let res;
+    if (data.id) {
+      res = await updateMaintenanceTaskByID(data.id, data);
+    } else {
+      res = await createMaintenanceTask(data);
+    }
+
+    return { success: res };
+  } catch (error) {
+    if (error instanceof PrismaClientKnownRequestError) {
+      console.error("[upsertMaintenanceTaskAction][PrismaKnownError]", error.code, error.message);
+    } else if (error instanceof PrismaClientUnknownRequestError) {
+      console.error("[upsertMaintenanceTaskAction][PrismaUnknownError]", error.message);
+    } else {
+      console.error("[upsertMaintenanceTaskAction]", error);
+    }
+
+    return { failure: "Request unsuccessful" };
+  }
+}
+
+export async function deleteMaintenanceTaskAction(id: string): Promise<GenericActionsType<MaintenanceTaskInclude>> {
+  const parsed = maintenanceTaskSchemaWithID.safeParse({ id: Number(id), title: "" });
+  if (!parsed.success) {
+    return { errors: parsed.error.format() };
+  }
+  try {
+    const res = await deleteMaintenanceTask(parsed.data.id);
+    return { success: res };
+  } catch (error) {
+    console.error(error);
+    return { failure: "Error deleting task" };
+  }
+}
+
+export async function fetchMaintenanceTasks(locationID?: number) {
+  return getMaintenanceTasks(undefined, locationID);
+}

--- a/src/app/(internal)/(dashboard_layout)/maintenance/page.tsx
+++ b/src/app/(internal)/(dashboard_layout)/maintenance/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import {useHeader} from "@/app/_context/HeaderContext";
+import React, {useEffect} from "react";
+import Link from "next/link";
+import {useQuery} from "@tanstack/react-query";
+import {AiOutlineLoading} from "react-icons/ai";
+import MaintenanceContent from "@/app/(internal)/(dashboard_layout)/maintenance/content";
+import {fetchMaintenanceTasks} from "@/app/(internal)/(dashboard_layout)/maintenance/maintenance-action";
+
+export default function MaintenancePage() {
+  const headerContext = useHeader();
+
+  useEffect(() => {
+    headerContext.setTitle("Tugas Maintenance");
+    headerContext.setShowLocationPicker(true);
+    headerContext.setPaths([
+      <Link key="maintenance" href="/maintenance">Maintenance</Link>,
+    ]);
+  }, []);
+
+  const { data: tasks, isLoading, isSuccess } = useQuery({
+    queryKey: ['maintenanceTasks', 'location_id', headerContext.locationID],
+    queryFn: () => fetchMaintenanceTasks(headerContext.locationID),
+  });
+
+  return (
+    <>
+      {isLoading && <span className="mx-auto h-8 w-8"><AiOutlineLoading className="animate-spin"/></span>}
+      {isSuccess && (
+        // @ts-ignore
+        <MaintenanceContent tasks={tasks}/>
+      )}
+    </>
+  );
+}

--- a/src/app/_components/sidebar/Sidebar.tsx
+++ b/src/app/_components/sidebar/Sidebar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import {FaBed, FaCalendar, FaCog, FaDatabase, FaMoneyBill, FaTachometerAlt, FaUserFriends} from 'react-icons/fa';
+import {FaBed, FaCalendar, FaCog, FaDatabase, FaMoneyBill, FaTachometerAlt, FaUserFriends, FaTools} from 'react-icons/fa';
 import styles from './sidebar.module.css';
 import {InteractiveUserDropdown, SidebarItem} from "@/app/_components/sidebar/SidebarItem";
 import {Session} from 'next-auth';
@@ -88,6 +88,7 @@ export default function Sidebar({session, companyInfo}: SidebarProps) {
         {name: 'Layanan Tambahan', path: '/addons', icon: <IoIosAddCircleOutline/>},
         {name: 'Pembayaran', path: '/payments', icon: <FaMoneyBill/>},
         {name: 'Tagihan', path: '/bills', icon: <FaReceipt/>},
+        {name: 'Maintenance', path: '/maintenance', icon: <FaTools/>},
         {
             name: 'Keuangan',
             path: '/financials',

--- a/src/app/_db/maintenance.ts
+++ b/src/app/_db/maintenance.ts
@@ -1,0 +1,63 @@
+"use server";
+
+import {MaintenanceTask, Prisma} from "@prisma/client";
+import prisma from "@/app/_lib/primsa";
+import {OmitIDTypeAndTimestamp} from "@/app/_db/db";
+
+export async function getMaintenanceTasks(id?: number, locationID?: number, limit?: number, offset?: number) {
+  return prisma.maintenanceTask.findMany({
+    where: {
+      id: id,
+      location_id: locationID,
+    },
+    include: {
+      rooms: true,
+      locations: true,
+    },
+    skip: offset,
+    take: limit,
+  });
+}
+
+export async function createMaintenanceTask(data: OmitIDTypeAndTimestamp<MaintenanceTask>) {
+  return prisma.maintenanceTask.create({
+    data: {
+      ...data,
+      id: undefined,
+    },
+    include: {
+      rooms: true,
+      locations: true,
+    },
+  });
+}
+
+export async function updateMaintenanceTaskByID(id: number, data: OmitIDTypeAndTimestamp<MaintenanceTask>) {
+  return prisma.maintenanceTask.update({
+    where: { id },
+    data: {
+      ...data,
+      id: undefined,
+    },
+    include: {
+      rooms: true,
+      locations: true,
+    },
+  });
+}
+
+export async function deleteMaintenanceTask(id: number) {
+  return prisma.maintenanceTask.delete({
+    where: { id },
+    include: {
+      rooms: true,
+      locations: true,
+    },
+  });
+}
+
+export async function getMaintenanceTaskById(id: number) {
+  return prisma.maintenanceTask.findUnique({
+    where: { id },
+  });
+}

--- a/src/app/_lib/zod/maintenance/zod.ts
+++ b/src/app/_lib/zod/maintenance/zod.ts
@@ -1,0 +1,15 @@
+import {date, number, object, string, union} from "zod";
+import {isoDateStringToDate} from "@/app/_lib/zod/base/zod";
+
+export const maintenanceTaskSchema = object({
+  title: string().min(1, "Title is required"),
+  description: string().nullable().optional(),
+  status: string().optional(),
+  due_date: union([isoDateStringToDate(), date()]).optional(),
+  room_id: number().optional(),
+  location_id: number().min(1, "Location ID is required"),
+});
+
+export const maintenanceTaskSchemaWithID = maintenanceTaskSchema.extend({
+  id: number().positive("ID must be a positive number"),
+});


### PR DESCRIPTION
## Summary
- introduce a `MaintenanceTask` Prisma model
- expose CRUD helpers for maintenance tasks
- add zod schema for task validation
- create maintenance dashboard page with form and table
- include Maintenance in sidebar navigation

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68466500b7948325a61873e7295aa179