### PR TITLE
Fix Financial Summary

### DIFF
--- a/__tests__/unit/dashboard-financial-summary.test.ts
+++ b/__tests__/unit/dashboard-financial-summary.test.ts
@@ -159,8 +159,21 @@ describe("getRecentTransactions", () => {
     prismaMock.transaction.findMany.mockResolvedValue([] as any);
   });
 
-  test("when includeDeposit is true, excludes Deposit category from results", async () => {
+  test("when includeDeposit is true, does not filter by category (deposits included)", async () => {
     await getRecentTransactions(undefined, true);
+
+    const call = prismaMock.transaction.findMany.mock.calls[0][0];
+    expect(call?.where?.category).toBeUndefined();
+    expect(prismaMock.transaction.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        orderBy: { date: "desc" },
+        take: 10,
+      })
+    );
+  });
+
+  test("when includeDeposit is false, excludes Deposit category", async () => {
+    await getRecentTransactions(undefined, false);
 
     expect(prismaMock.transaction.findMany).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -171,13 +184,6 @@ describe("getRecentTransactions", () => {
         take: 10,
       })
     );
-  });
-
-  test("when includeDeposit is false, does not filter by category", async () => {
-    await getRecentTransactions(undefined, false);
-
-    const call = prismaMock.transaction.findMany.mock.calls[0][0];
-    expect(call?.where?.category).toBeUndefined();
   });
 
   test("passes location_id to findMany when provided", async () => {

--- a/__tests__/unit/dashboard-financial-summary.test.ts
+++ b/__tests__/unit/dashboard-financial-summary.test.ts
@@ -2,7 +2,7 @@ import {afterEach, beforeEach, describe, expect, jest, test} from "@jest/globals
 import {DeepMockProxy, mockDeep, mockReset} from "jest-mock-extended";
 import {PrismaClient} from "@prisma/client";
 
-import {getGroupedIncomeExpense} from "@/app/_db/dashboard";
+import {getGroupedIncomeExpense, getRecentTransactions} from "@/app/_db/dashboard";
 import {Period} from "@/app/_enum/financial";
 import prisma from "@/app/_lib/primsa";
 
@@ -35,7 +35,7 @@ describe("getGroupedIncomeExpense extended periods", () => {
     });
 
     expect(result.labels).toEqual(["01-01-2024", "02-01-2024", "03-01-2024"]);
-    expect(prismaMock.transaction.findMany).toHaveBeenCalledTimes(2);
+    expect(prismaMock.transaction.findMany).toHaveBeenCalledTimes(4);
   });
 
   test("uses monthly labels for long custom range", async () => {
@@ -65,7 +65,129 @@ describe("getGroupedIncomeExpense extended periods", () => {
     const result = await getGroupedIncomeExpense(Period.SEVEN_DAYS, 1);
 
     expect(result.labels.length).toBeGreaterThanOrEqual(7);
-    expect(prismaMock.transaction.findMany).toHaveBeenCalledTimes(2);
+    expect(prismaMock.transaction.findMany).toHaveBeenCalledTimes(4);
+  });
+});
+
+describe("getGroupedIncomeExpense deposit split", () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+    prismaMock.transaction.findMany.mockResolvedValue([] as any);
+    prismaMock.transaction.aggregate.mockResolvedValue({ _min: { date: null } } as any);
+    jest.useFakeTimers().setSystemTime(new Date("2024-07-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("when splitDeposit is true, main income/expense queries exclude Deposit category", async () => {
+    await getGroupedIncomeExpense(
+      { type: "custom", range: { startDate: new Date("2024-01-01"), endDate: new Date("2024-01-03") } },
+      undefined,
+      true
+    );
+
+    const incomeCalls = prismaMock.transaction.findMany.mock.calls.filter(
+      (c) => c[0]?.where?.type === "INCOME" && c[0]?.where?.category
+    );
+    const expenseCalls = prismaMock.transaction.findMany.mock.calls.filter(
+      (c) => c[0]?.where?.type === "EXPENSE" && c[0]?.where?.category
+    );
+    expect(incomeCalls.length).toBeGreaterThanOrEqual(1);
+    expect(expenseCalls.length).toBeGreaterThanOrEqual(1);
+    expect(incomeCalls[0][0]?.where?.category).toEqual({ not: "Deposit" });
+    expect(expenseCalls[0][0]?.where?.category).toEqual({ not: "Deposit" });
+  });
+
+  test("when splitDeposit is true, result includes deposit.income and deposit.expense aligned to labels", async () => {
+    const result = await getGroupedIncomeExpense(
+      { type: "custom", range: { startDate: new Date("2024-01-01"), endDate: new Date("2024-01-03") } },
+      undefined,
+      true
+    );
+
+    expect(result.deposit).toBeDefined();
+    expect(result.deposit!.income).toHaveLength(result.labels.length);
+    expect(result.deposit!.expense).toHaveLength(result.labels.length);
+    expect(Array.isArray(result.deposit!.income[0])).toBe(true);
+    expect(Array.isArray(result.deposit!.expense[0])).toBe(true);
+  });
+
+  test("when splitDeposit is false, result still includes deposit arrays", async () => {
+    const result = await getGroupedIncomeExpense(
+      { type: "custom", range: { startDate: new Date("2024-01-01"), endDate: new Date("2024-01-03") } },
+      undefined,
+      false
+    );
+
+    expect(result.deposit).toBeDefined();
+    expect(result.deposit!.income).toHaveLength(result.labels.length);
+    expect(result.deposit!.expense).toHaveLength(result.labels.length);
+  });
+});
+
+describe("getGroupedIncomeExpense locationID", () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+    prismaMock.transaction.findMany.mockResolvedValue([] as any);
+    prismaMock.transaction.aggregate.mockResolvedValue({ _min: { date: null } } as any);
+    jest.useFakeTimers().setSystemTime(new Date("2024-07-01T00:00:00.000Z"));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  test("passes location_id to transaction findMany and aggregate when provided", async () => {
+    await getGroupedIncomeExpense(
+      { type: "custom", range: { startDate: new Date("2024-01-01"), endDate: new Date("2024-01-03") } },
+      42,
+      false
+    );
+
+    const findManyCalls = prismaMock.transaction.findMany.mock.calls;
+    findManyCalls.forEach((call) => {
+      expect(call[0]?.where?.location_id).toBe(42);
+    });
+  });
+});
+
+describe("getRecentTransactions", () => {
+  beforeEach(() => {
+    mockReset(prismaMock);
+    prismaMock.transaction.findMany.mockResolvedValue([] as any);
+  });
+
+  test("when includeDeposit is true, excludes Deposit category from results", async () => {
+    await getRecentTransactions(undefined, true);
+
+    expect(prismaMock.transaction.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          category: { not: "Deposit" },
+        }),
+        orderBy: { date: "desc" },
+        take: 10,
+      })
+    );
+  });
+
+  test("when includeDeposit is false, does not filter by category", async () => {
+    await getRecentTransactions(undefined, false);
+
+    const call = prismaMock.transaction.findMany.mock.calls[0][0];
+    expect(call?.where?.category).toBeUndefined();
+  });
+
+  test("passes location_id to findMany when provided", async () => {
+    await getRecentTransactions(99, false);
+
+    expect(prismaMock.transaction.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ location_id: 99 }),
+      })
+    );
   });
 });
 

--- a/public/changelogs/v0.5.2.md
+++ b/public/changelogs/v0.5.2.md
@@ -1,0 +1,16 @@
+---
+version: "v0.5.2"
+date: "2026-02-05"
+importance: "minor"
+prevVersion: "v0.5.1"
+---
+
+# Apa yang baru di v0.5.2 ✨
+
+## 🎉 Fitur Baru
+- Transaksi deposit kini ditampilkan terpisah di halaman Ringkasan Keuangan
+- Tabel transaksi deposit baru untuk melihat pemasukan dan pengeluaran deposit secara khusus
+- Opsi untuk menyertakan atau mengecualikan deposit dari daftar transaksi terkini
+
+## 🐛 Perbaikan & Penyesuaian
+- Optimasi pengelompokan transaksi berdasarkan periode waktu

--- a/src/app/(internal)/(dashboard_layout)/dashboard/_components/financial-graph.tsx
+++ b/src/app/(internal)/(dashboard_layout)/dashboard/_components/financial-graph.tsx
@@ -19,7 +19,7 @@ export default function FinancialGraph() {
         isSuccess,
     } = useQuery({
         queryKey: ["groupedIncomeExpense", selectedPeriod, headerContext.locationID],
-        queryFn: () => getGroupedIncomeExpense(selectedPeriod, headerContext.locationID),
+        queryFn: () => getGroupedIncomeExpense(selectedPeriod, headerContext.locationID, true),
     });
 
     useEffect(() => {

--- a/src/app/(internal)/(dashboard_layout)/dashboard/_components/financial-graph.tsx
+++ b/src/app/(internal)/(dashboard_layout)/dashboard/_components/financial-graph.tsx
@@ -18,7 +18,7 @@ export default function FinancialGraph() {
         isLoading,
         isSuccess,
     } = useQuery({
-        queryKey: ["transaction", selectedPeriod, headerContext.locationID],
+        queryKey: ["groupedIncomeExpense", selectedPeriod, headerContext.locationID],
         queryFn: () => getGroupedIncomeExpense(selectedPeriod, headerContext.locationID),
     });
 

--- a/src/app/(internal)/(dashboard_layout)/dashboard/dashboard-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/dashboard/dashboard-action.ts
@@ -1,9 +1,9 @@
 "use server";
 
+import type {GroupedIncomeExpenseArgs} from "@/app/_db/dashboard";
 import {getGroupedIncomeExpense, getOverviewData, getRecentTransactions} from "@/app/_db/dashboard";
 import {serializeForClient} from "@/app/_lib/util/prisma";
 import {Period} from "@/app/_enum/financial";
-import type {GroupedIncomeExpenseArgs} from "@/app/_db/dashboard";
 
 const toClient = <T>(value: T) => serializeForClient(value);
 
@@ -13,11 +13,12 @@ export async function getOverviewDataAction(locationID?: number) {
 
 export async function getGroupedIncomeExpenseAction(
   periodOrOptions: Period | GroupedIncomeExpenseArgs,
-  locationID?: number
+  locationID?: number,
+  splitDeposit?: boolean
 ) {
-  return getGroupedIncomeExpense(periodOrOptions, locationID).then(toClient);
+  return getGroupedIncomeExpense(periodOrOptions, locationID, splitDeposit).then(toClient);
 }
 
-export async function getRecentTransactionsAction(locationID?: number) {
-  return getRecentTransactions(locationID).then(toClient);
+export async function getRecentTransactionsAction(locationID?: number, includeDeposit?: boolean) {
+  return getRecentTransactions(locationID, includeDeposit).then(toClient);
 }

--- a/src/app/(internal)/(dashboard_layout)/financials/summary/content.tsx
+++ b/src/app/(internal)/(dashboard_layout)/financials/summary/content.tsx
@@ -121,7 +121,7 @@ const sectionRefs = useRef<Record<ExpandableSection, HTMLDivElement | null>>({
 
     const {data: recentTransactions, isLoading: isRecentLoading, isSuccess: isRecentSuccess} = useQuery({
         queryKey: ["recentTransactions", headerContext.locationID, recentTransactionsIncludeDeposit],
-        queryFn: () => getRecentTransactionsAction(headerContext.locationID, !recentTransactionsIncludeDeposit),
+        queryFn: () => getRecentTransactionsAction(headerContext.locationID, recentTransactionsIncludeDeposit),
     });
 
     // Category Breakdown

--- a/src/app/_components/financials/income-expense-graph.tsx
+++ b/src/app/_components/financials/income-expense-graph.tsx
@@ -6,6 +6,7 @@ import {CategoryScale, Chart as ChartJS, Legend, LinearScale, LineElement, Point
 import {Line} from "react-chartjs-2";
 import {AiOutlineLoading} from "react-icons/ai";
 import {Period} from "@/app/_enum/financial";
+import {SimplifiedIncomeExpense} from "@/app/_db/dashboard";
 
 ChartJS.register(LineElement, PointElement, LinearScale, CategoryScale, Tooltip, Legend);
 
@@ -24,11 +25,7 @@ export type IncomeExpenseGraphProps = (
     title?: ReactElement;
     isSuccess: boolean;
     isLoading: boolean;
-    data?: {
-        labels: string[];
-        incomeData: number[];
-        expenseData: number[];
-    }
+    data?: SimplifiedIncomeExpense
 };
 
 export default function IncomeExpenseGraph({

--- a/src/app/_db/dashboard.ts
+++ b/src/app/_db/dashboard.ts
@@ -485,7 +485,7 @@ export async function getRecentTransactions(locationID?: number, includeDeposit?
     return prisma.transaction.findMany({
         where: {
             location_id: locationID,
-            ...(includeDeposit ? {
+            ...(!includeDeposit ? {
                 category: {
                     not: 'Deposit'
                 }

--- a/src/app/_lib/util/chart.ts
+++ b/src/app/_lib/util/chart.ts
@@ -3,16 +3,23 @@ import {GroupedIncomeExpense, SimplifiedIncomeExpense} from "@/app/_db/dashboard
 import type {ChartData} from "chart.js";
 
 export function convertGroupedTransactionsToTotals(groupedData: GroupedIncomeExpense): SimplifiedIncomeExpense {
-  const { labels, incomeData, expenseData } = groupedData;
+  const { labels, incomeData, expenseData, deposit } = groupedData;
 
   const totalIncomeData = incomeData.map((transactions) => transactions.reduce((sum, tx) => sum + Number(tx.amount), 0));
 
   const totalExpenseData = expenseData.map((transactions) => transactions.reduce((sum, tx) => sum + Number(tx.amount), 0));
 
+  const totalDepositExpenseData = deposit?.expense.map((transactions) => transactions.reduce((sum, tx) => sum + Number(tx.amount), 0));
+  const totalDepositIncomeData = deposit?.income.map((transactions) => transactions.reduce((sum, tx) => sum + Number(tx.amount), 0));
+
   return {
     labels,
     incomeData: totalIncomeData,
     expenseData: totalExpenseData,
+    deposit: (totalDepositExpenseData && totalDepositIncomeData) ?{
+      expense: totalDepositExpenseData,
+      income: totalDepositIncomeData,
+    } : undefined,
   };
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches core financial aggregation queries and changes API shapes/React Query keys, which can affect dashboard correctness and caching. Main risk is mismatched data expectations (deposit inclusion/exclusion) and the extra DB queries impacting performance.
> 
> **Overview**
> Updates financial summary data fetching to optionally **split `Deposit` transactions** from the main income/expense series. `getGroupedIncomeExpense` now returns a new `deposit` series (income+expense) and, when enabled, excludes deposits from the primary queries; `getRecentTransactions` adds an `includeDeposit` flag to optionally filter out deposits.
> 
> The dashboard UI is updated to use the new API shape: the main graph requests `splitDeposit=true`, the financial summary adds a dedicated deposit table, category breakdown includes deposit data, and the “Recent Transactions” section adds a toggle to include/exclude deposits. Tests are expanded to cover deposit splitting behavior, location filtering propagation, and the updated query counts/API signatures; a new `v0.5.2` changelog documents the feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d9fa6e465c086f70a4f12c83f2df876e7778088b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->