### PR TITLE
Add HMS documentation hub and onboarding/runbooks; update README with setup and test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,69 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# HMS
 
-## Getting Started
+HMS is a Next.js + Prisma based management platform for room/property operations:
 
-First, run the development server:
+- bookings (fixed-term + rolling)
+- residents (tenants + guests)
+- billing, payments, deposits
+- financial reporting and exports
+- scheduled jobs for monthly billing and invoice reminders
+
+## Documentation
+
+Start here:
+
+- [Documentation Hub](docs/README.md)
+- [Onboarding Guide](docs/onboarding.md)
+- [Architecture Guide](docs/architecture.md)
+- [Runbooks](docs/runbooks.md)
+- [Cron Jobs](docs/cron-jobs.md)
+
+## Getting started
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Copy env:
+
+```bash
+cp env.example .env
+```
+
+3. Start DB (docker):
+
+```bash
+docker compose -f .docker/docker-compose.yml up -d db
+```
+
+4. Generate prisma client and migrate:
+
+```bash
+npm run prisma-gen
+npm run prisma-migrate
+```
+
+5. Start app:
 
 ```bash
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open `http://localhost:3000`.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Tests
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+```bash
+npm test
+npm run test:integration
+```
 
-## Learn More
+For integration DB helper:
 
-To learn more about Next.js, take a look at the following resources:
-
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
-
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+```bash
+./scripts/intg-test-db.sh up
+npm run test:integration
+./scripts/intg-test-db.sh down
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,43 @@
+# HMS Documentation Hub
+
+Welcome to the HMS documentation hub. Use these docs for onboarding, architecture understanding, and day-to-day operations.
+
+## Documents
+
+1. **[Onboarding Guide](./onboarding.md)**
+   - Quick project orientation
+   - Local development setup
+   - Common workflows
+   - Key concepts and glossary
+
+2. **[Architecture Guide](./architecture.md)**
+   - System context and module boundaries
+   - Request flow and data flow
+   - Core domain model (bookings, bills, payments, deposits, add-ons)
+   - Important design decisions and edge cases
+
+3. **[Runbooks](./runbooks.md)**
+   - Service startup/shutdown
+   - Database operations
+   - Cron operation/debugging
+   - Incident response playbooks
+   - Deployment/CI troubleshooting
+
+4. **[Cron Jobs Documentation](./cron-jobs.md)**
+   - Monthly billing and reminder jobs
+   - Debug endpoints and operational notes
+
+## Intended audience
+
+- **New engineers**: start from `onboarding.md`, then `architecture.md`.
+- **On-call/operations**: keep `runbooks.md` and `cron-jobs.md` handy.
+- **Feature development**: use `architecture.md` + code references from onboarding.
+
+## Current stack at a glance
+
+- Next.js (App Router), React, TypeScript
+- Prisma + PostgreSQL
+- NextAuth (credentials)
+- AWS S3/SES integration points
+- Jest unit + integration test suites
+- Optional Cronicle container for scheduled jobs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -145,10 +145,10 @@ Rules implemented in code:
 
 ```mermaid
 flowchart TD
-  C[Cronicle / scheduler] --> MB[/api/cron/monthly-billing]
-  C --> ER[/api/tasks/email/invoice-reminder]
+  C["Cronicle / scheduler"] --> MB["/api/cron/monthly-billing"]
+  C --> ER["/api/tasks/email/invoice-reminder"]
   MB --> B[(bills table)]
-  ER --> M[mailer transport]
+  ER --> M["mailer transport"]
   ER --> EL[(emaillogs table)]
 ```
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,175 @@
+# HMS Architecture Guide
+
+This document explains how HMS is structured and how core business flows work.
+
+---
+
+## 1) High-level architecture
+
+```mermaid
+flowchart LR
+  U[User Browser] --> N[Next.js App Router]
+  N --> SA[Server Actions]
+  N --> API[API Routes]
+  SA --> DBL[_db data layer]
+  API --> DBL
+  DBL --> P[(PostgreSQL via Prisma)]
+  SA --> S3[(AWS S3)]
+  SA --> SES[(Email via Nodemailer/SES integration)]
+  SA --> AX[Axiom Logging]
+```
+
+### Layers
+
+1. **Presentation/UI**: pages/components under `src/app`.
+2. **Action/API layer**: server actions in feature folders + route handlers in `src/app/api`.
+3. **Data access layer**: `src/app/_db/*`.
+4. **Persistence**: Prisma schema + PostgreSQL.
+5. **Integrations**: S3 (files), email transport, logging.
+
+---
+
+## 2) Next.js route grouping
+
+- `(external)` route group: auth pages (`/login`, `/register`, etc.).
+- `(internal)` route group: protected app.
+- `(dashboard_layout)` nested group: actual business modules (bookings, payments, bills, deposits, rooms, financials, settings, etc.).
+
+Auth/guard behavior:
+
+- internal layout checks session; redirects to `/login` if unauthenticated.
+- dashboard layout also checks setup flag; redirects to `/first-time-setup` if needed.
+
+---
+
+## 3) Core domain model (simplified)
+
+```mermaid
+erDiagram
+  BOOKING ||--o{ BILL : has
+  BILL ||--o{ BILL_ITEM : has
+  BOOKING ||--o{ PAYMENT : has
+  PAYMENT ||--o{ PAYMENT_BILL : allocates
+  BILL ||--o{ PAYMENT_BILL : receives
+  BOOKING ||--o| DEPOSIT : has
+  BOOKING ||--o{ BOOKING_ADDON : has
+  BOOKING_ADDON }o--|| ADDON : uses
+  ADDON ||--o{ ADDON_PRICING : has
+  BOOKING }o--|| ROOM : assigned_to
+  ROOM }o--|| LOCATION : at
+  BOOKING }o--|| TENANT : occupied_by
+  TRANSACTION }o--|| LOCATION : belongs_to
+```
+
+### Important modeling choices
+
+- `PaymentBill` is a junction table representing how a payment is distributed to one/many bills.
+- Deposit is separate entity with status machine and references in bill items / transactions.
+- `Transaction.related_id` (JSON) stores links like `payment_id`, `booking_id`, `deposit_id`.
+- Add-ons support tiered pricing intervals and full-payment mode.
+
+---
+
+## 4) Request flow (example: create payment)
+
+```mermaid
+sequenceDiagram
+  participant UI as Payments UI
+  participant SA as payment-action.ts
+  participant BL as bill-action.ts
+  participant DB as Prisma/DB
+  participant S3 as AWS S3
+
+  UI->>SA: upsertPaymentAction(payload)
+  alt payment proof file included
+    SA->>S3: upload proof
+  end
+  SA->>DB: create/update payment (transaction)
+  alt allocationMode = auto
+    SA->>BL: getUnpaidBillsDueAction()
+    SA->>BL: simulateUnpaidBillPaymentAction()
+    SA->>DB: create payment_bills rows
+  else allocationMode = manual
+    SA->>DB: validate and write manual payment_bills
+  end
+  SA->>DB: createOrUpdatePaymentTransactions()
+  SA-->>UI: success/failure response
+```
+
+What makes this flow non-trivial:
+
+- Allocation and transaction records are kept in sync.
+- Deposit and regular income are split from bill-item composition.
+- Editing a payment can trigger recalculation for all affected payments in a booking.
+
+---
+
+## 5) Booking and billing logic
+
+### Fixed-term bookings
+
+- Duration is mapped to calculated end date.
+- Overlap checks ensure no active conflicting booking in same room.
+- Bills are generated for defined period.
+
+### Rolling bookings
+
+- `is_rolling=true` means recurring monthly behavior.
+- Initial bill generation can create historical/current bills from start date to current month.
+- Monthly cron creates next bill only when needed.
+- End-of-stay scheduling converts rolling to non-rolling and trims future billing.
+
+---
+
+## 6) Deposit lifecycle behavior
+
+Supported statuses:
+
+- `UNPAID`
+- `HELD`
+- `APPLIED`
+- `REFUNDED`
+- `PARTIALLY_REFUNDED`
+- `FORFEITED`
+
+Rules implemented in code:
+
+- Deposit is usually represented as bill item on first bill.
+- When deposit payment is recognized, status can move from `UNPAID` to `HELD`.
+- `APPLIED` does **not** create additional income (to avoid double counting).
+- Refund transitions create expense transactions.
+
+---
+
+## 7) Scheduled jobs architecture
+
+```mermaid
+flowchart TD
+  C[Cronicle / scheduler] --> MB[/api/cron/monthly-billing]
+  C --> ER[/api/tasks/email/invoice-reminder]
+  MB --> B[(bills table)]
+  ER --> M[mailer transport]
+  ER --> EL[(emaillogs table)]
+```
+
+- Cron endpoints use `CRON_SECRET` verification.
+- Debug endpoints exist to simulate behavior without production writes.
+
+---
+
+## 8) Test strategy
+
+- **Unit tests**: logic-heavy modules (booking lifecycle, payment allocation, deposits, utility functions).
+- **Integration tests**: DB-backed behavior via Prisma + test Postgres.
+- CI runs both test suites.
+
+---
+
+## 9) Known complexity hotspots
+
+1. Payment editing with reallocation across bills and transactions.
+2. Rolling booking mutations that regenerate bills and preserve historical correctness.
+3. Deposit accounting consistency (historical migration scripts indicate prior data correction work).
+4. Add-on tiered pricing proration across arbitrary booking periods.
+
+When changing these areas, favor tests first and verify financial totals before and after.

--- a/docs/onboarding.md
+++ b/docs/onboarding.md
@@ -1,0 +1,218 @@
+# HMS Onboarding Guide
+
+This guide is for engineers onboarding to HMS (Housing/Hotel Management System).
+
+---
+
+## 1) What this product is
+
+HMS is an internal operations platform for managing:
+
+- Rooms and room types
+- Tenants and guests
+- Bookings (fixed-term and rolling)
+- Bills, payments, and deposits
+- Financial transactions and exports
+- Optional recurring jobs (monthly billing + reminder emails)
+
+The UI language is largely Indonesian, while technical enum values are stored in English and translated in UI.
+
+---
+
+## 2) Repository structure
+
+```text
+src/app/
+  (external)/             # unauthenticated pages (login/register/reset)
+  (internal)/             # authenticated app
+    (dashboard_layout)/   # main product modules
+  api/                    # API routes (auth, cron, debug, exports)
+  _db/                    # DB access layer
+  _lib/                   # auth, utilities, zod schemas, mailer, integrations
+  _components/            # reusable UI components
+prisma/
+  schema.prisma           # DB schema
+  migrations/             # migration history
+  scripts/                # one-off SQL scripts and fixes
+__tests__/
+  unit/                   # fast unit tests
+  integration/            # DB-backed integration tests
+docs/
+  *.md                    # project docs/runbooks
+```
+
+---
+
+## 3) Prerequisites
+
+- Node.js 18+ (CI uses Node 18)
+- npm
+- Docker (recommended for local Postgres + optional cron stack)
+
+---
+
+## 4) Local setup (happy path)
+
+1. Install dependencies:
+
+```bash
+npm install
+```
+
+2. Copy environment variables:
+
+```bash
+cp env.example .env
+```
+
+3. Start local DB (option A - Docker compose):
+
+```bash
+docker compose -f .docker/docker-compose.yml up -d db
+```
+
+4. Generate Prisma client and apply schema:
+
+```bash
+npm run prisma-gen
+npm run prisma-migrate
+```
+
+5. Start app:
+
+```bash
+npm run dev
+```
+
+6. Open app:
+
+```text
+http://localhost:3000
+```
+
+---
+
+## 5) First-time app initialization
+
+The app enforces initial setup using `APP_SETUP` setting.
+
+Flow:
+
+1. Login succeeds.
+2. Internal layout checks `settings.APP_SETUP`.
+3. If false/missing, user is redirected to `/first-time-setup`.
+4. Wizard collects company name/logo and initial location.
+
+Tip: if you are locked out of dashboard in local dev, verify `settings` table values.
+
+---
+
+## 6) Core modules to learn first
+
+1. **Bookings**
+   - fixed-term and rolling bookings
+   - overlap checks
+   - check-in/check-out and end-of-stay scheduling
+
+2. **Bills + Payments**
+   - auto-generated bills
+   - payment allocation (auto/manual)
+   - payment-to-bill mapping
+
+3. **Deposits**
+   - lifecycle status transitions
+   - interaction with payment transactions
+   - refund expense transactions
+
+4. **Financials**
+   - transaction listing
+   - PDF/Excel export
+
+5. **Cron jobs**
+   - monthly rolling-bill generation
+   - invoice reminder emails
+
+---
+
+## 7) Development workflows
+
+### Run tests
+
+```bash
+npm test
+npm run test:integration
+```
+
+Integration tests expect a reachable Postgres DB. Use helper script:
+
+```bash
+./scripts/intg-test-db.sh up
+npm run test:integration
+./scripts/intg-test-db.sh down
+```
+
+### Database migration workflow
+
+```bash
+npm run prisma-migrate
+```
+
+Then commit both:
+
+- new migration under `prisma/migrations/*`
+- updated generated Prisma client artifacts (if applicable)
+
+### Logging and observability
+
+- Axiom client/server wrappers are under `src/app/_lib/axiom/`.
+- Server actions frequently call `after(() => serverLogger.flush())`.
+
+---
+
+## 8) Environment variables (core)
+
+From root app usage and examples:
+
+- `DATABASE_URL`
+- `AUTH_SECRET`
+- `CRON_SECRET`
+- `AWS_REGION`
+- `S3_BUCKET`
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
+- `AXIOM_DATASET`, `AXIOM_TOKEN`
+- `NODE_ENV`
+
+Cron stack also uses:
+
+- `HMS_BASE_URL`
+- `HMS_CRON_SECRET`
+- `SMTP_*`
+- `CRONICLE_*`
+
+---
+
+## 9) Common onboarding pitfalls
+
+1. **No dashboard access after login**
+   - likely first-time setup not completed (`APP_SETUP=false`)
+
+2. **Integration tests fail immediately**
+   - test DB is not running / `DATABASE_URL` mismatch
+
+3. **S3 upload errors during payment proof upload**
+   - missing AWS credentials / region / bucket
+
+4. **Cron endpoint unauthorized**
+   - missing/invalid `CRON_SECRET` header for cron calls
+
+---
+
+## 10) Suggested first-day learning path
+
+1. Read `docs/architecture.md`.
+2. Walk through booking creation path:
+   - UI form -> booking action -> `_db/bookings.ts` -> bill creation.
+3. Walk through payment creation path:
+   - payment action -> allocation -> transaction updates.
+4. Run unit tests for booking/payment/deposit behavior.
+5. Read `docs/runbooks.md` before touching production-like operations.

--- a/docs/runbooks.md
+++ b/docs/runbooks.md
@@ -1,0 +1,366 @@
+# HMS Runbooks
+
+Operational runbooks for development, staging, and production-like support.
+
+> Audience: engineers, on-call responders, and maintainers.
+
+---
+
+## 0) Quick command index
+
+### App
+
+```bash
+npm install
+npm run dev
+npm run build
+npm run start
+```
+
+### Prisma
+
+```bash
+npm run prisma-gen
+npm run prisma-migrate
+npx prisma migrate deploy
+npx prisma db push
+npx prisma validate
+```
+
+### Tests
+
+```bash
+npm test
+npm run test:integration
+./scripts/intg-test-db.sh up
+./scripts/intg-test-db.sh down
+```
+
+### Docker
+
+```bash
+docker compose -f .docker/docker-compose.yml up -d
+docker compose -f .docker/docker-compose.yml down
+docker compose -f .docker/docker-compose.test-db.yml up -d
+docker compose -f .docker/docker-compose.test-db.yml down -v
+```
+
+---
+
+## 1) Service startup runbook (local)
+
+### Goal
+
+Start HMS app and database locally for development.
+
+### Steps
+
+1. Ensure `.env` exists (copy from `env.example`).
+2. Start DB:
+
+```bash
+docker compose -f .docker/docker-compose.yml up -d db
+```
+
+3. Run migrations and generate client:
+
+```bash
+npm run prisma-gen
+npm run prisma-migrate
+```
+
+4. Start app:
+
+```bash
+npm run dev
+```
+
+5. Validate:
+
+- open `http://localhost:3000`
+- confirm login or first-time setup page is reachable
+
+### Rollback / stop
+
+```bash
+docker compose -f .docker/docker-compose.yml down
+```
+
+---
+
+## 2) Integration test DB runbook
+
+### Goal
+
+Run integration tests against isolated Postgres.
+
+### Steps
+
+```bash
+./scripts/intg-test-db.sh up
+npm run test:integration
+./scripts/intg-test-db.sh down
+```
+
+### Failure modes
+
+- DB container not healthy: inspect docker logs for `test-db` service.
+- Prisma migration failure: ensure `DATABASE_URL` points to test DB port `55432`.
+
+---
+
+## 3) Database schema change runbook
+
+### Goal
+
+Safely introduce schema and code changes.
+
+### Steps
+
+1. Update Prisma schema.
+2. Create migration:
+
+```bash
+npm run prisma-migrate
+```
+
+3. Run tests:
+
+```bash
+npm test
+npm run test:integration
+```
+
+4. Verify migration SQL under `prisma/migrations/*`.
+5. Commit schema + migration + related code changes.
+
+### Production notes
+
+- CI includes Prisma validation/db push workflow on `main`.
+- For risky financial changes, prepare one-off verification SQL and rollback SQL (pattern already used in `prisma/scripts/`).
+
+---
+
+## 4) Payment allocation incident runbook
+
+### Symptoms
+
+- A booking shows inconsistent paid totals.
+- Transaction totals do not match expected bill allocation.
+- Deposit status appears incorrect after payment edit.
+
+### Investigation checklist
+
+1. Identify affected `booking_id` and `payment_id`.
+2. Inspect payment allocations (`payment_bills`) for the booking.
+3. Inspect `bill_items` and check deposit-related item markers (`related_id.deposit_id`).
+4. Inspect `transactions` filtered by `related_id.payment_id`.
+5. Compare amounts:
+   - payment total
+   - allocated amount sum
+   - regular income + deposit income transaction totals
+
+### Remediation
+
+- Re-run payment update flow using application path if possible (preferred).
+- If manual correction required, do DB transaction with before/after snapshots.
+- Add/adjust unit tests for reproduced edge case before closing incident.
+
+---
+
+## 5) Deposit status incident runbook
+
+### Symptoms
+
+- Deposit stuck in wrong status (`UNPAID` vs `HELD`, etc.).
+- Refund recorded but no expense transaction.
+- Double-counted income suspicion.
+
+### Investigation
+
+1. Find deposit row by booking.
+2. Inspect related bill item (`related_id.deposit_id`).
+3. Check payment allocations touching deposit bill item.
+4. Check transaction rows in category `Deposit` for this booking/payment.
+
+### Expected behaviors
+
+- `APPLIED`: no new income transaction.
+- `REFUNDED` / `PARTIALLY_REFUNDED`: creates expense transaction.
+- paid deposit generally implies `HELD`.
+
+### Remediation
+
+- Use deposit status update action path (not ad-hoc SQL) where possible.
+- Backfill missing transactions only with documented SQL scripts and peer review.
+
+---
+
+## 6) Rolling monthly billing runbook
+
+### Goal
+
+Ensure recurring bills are generated for active rolling bookings.
+
+### Trigger
+
+- Scheduled monthly (1st day) via cron endpoint.
+
+### Manual invocation
+
+```bash
+curl -X POST "http://localhost:3000/api/cron/monthly-billing" \
+  -H "x-cron-secret: <CRON_SECRET>"
+```
+
+### Debug simulation endpoint
+
+```bash
+curl "http://localhost:3000/api/debug/cron/monthly-billing?target_date=2024-09-01" \
+  -H "Authorization: Bearer <auth_token>"
+```
+
+### Verification
+
+- check response summary (`processed`, `created` counts)
+- inspect newly created bills for sample booking IDs
+
+---
+
+## 7) Invoice reminder runbook
+
+### Goal
+
+Send reminders for unpaid bills approaching due date.
+
+### Manual invocation
+
+```bash
+curl "http://localhost:3000/api/tasks/email/invoice-reminder" \
+  -H "x-cron-secret: <CRON_SECRET>"
+```
+
+### Debug simulation
+
+```bash
+curl "http://localhost:3000/api/debug/tasks/email/invoice-reminder?start_date=2024-09-28" \
+  -H "Authorization: Bearer <auth_token>"
+```
+
+### Verification
+
+- validate reminder count from endpoint response
+- inspect `emaillogs` entries
+- check setting `MONTHLY_INVOICE_EMAIL_REMINDER_ENABLED`
+
+---
+
+## 8) Cronicle stack runbook
+
+### Goal
+
+Run scheduled jobs using the included cron container.
+
+### Setup
+
+1. Copy and edit cron env:
+
+```bash
+cp cron/env.example cron/.env
+```
+
+2. Start cron stack:
+
+```bash
+docker compose -f cron/docker-compose.yml --env-file cron/.env up -d
+```
+
+3. Open Cronicle UI at `http://localhost:3012`.
+
+### Stop
+
+```bash
+docker compose -f cron/docker-compose.yml --env-file cron/.env down
+```
+
+### Common issues
+
+- wrong `HMS_BASE_URL` (cron cannot reach app)
+- missing `HMS_CRON_SECRET`
+- SMTP auth failures
+
+---
+
+## 9) S3 upload failure runbook (payment proof)
+
+### Symptoms
+
+- Payment submission fails when proof file attached.
+- Error logs indicate PutObject failure.
+
+### Checklist
+
+- `AWS_REGION` configured
+- `S3_BUCKET` configured
+- IAM credentials present and valid
+- bucket policy allows put/delete
+
+### Safe fallback
+
+- retry payment creation without proof upload for business continuity
+- attach proof later after credentials fixed
+
+---
+
+## 10) CI failure runbook
+
+### Common failing jobs
+
+1. `Run Tests` workflow
+   - unit test failures
+   - integration test DB/migration issues
+
+2. `Prisma DB Push` workflow on `main`
+   - invalid `DATABASE_URL` secret
+   - schema validation errors
+
+### Response procedure
+
+1. Identify first failing step.
+2. Reproduce locally with same command.
+3. Fix or revert offending commit.
+4. Re-run CI.
+
+---
+
+## 11) Incident severity and communication template
+
+### Severity quick guide
+
+- **SEV-1**: production down or financial corruption risk
+- **SEV-2**: major feature degraded (payments/billing broken)
+- **SEV-3**: localized bug with workaround
+
+### Incident note template
+
+```text
+Title: [SEV-X] <short description>
+Start time:
+Detected by:
+Affected module(s):
+Customer impact:
+Current status:
+Mitigation:
+Next update ETA:
+Owner:
+```
+
+---
+
+## 12) Post-incident checklist
+
+- Root cause documented
+- Data corrections audited
+- Tests added for regression
+- Runbook updated
+- Action items tracked with owners/dates


### PR DESCRIPTION
### Motivation

- Provide a centralized documentation hub and onboarding materials to speed up developer ramp-up and reduce operational friction.  
- Capture architecture, domain model, and scheduled job behavior to improve knowledge transfer and maintenance.  
- Make local setup and testing steps explicit (Prisma, Docker test DB, and integration test helpers) so contributors can reproducibly run the app and tests.

### Description

- Replace the project `README.md` with an HMS-focused guide that includes quickstart steps, `cp env.example .env`, `docker compose` DB instructions, and `npm run prisma-gen` / `npm run prisma-migrate` usage.  
- Add a `docs/` documentation hub and index at `docs/README.md` linking to onboarding, architecture, runbooks, and cron job docs.  
- Add `docs/architecture.md` documenting high-level architecture, route grouping, core domain model, booking/billing/deposit behavior, scheduled jobs, and test strategy.  
- Add `docs/onboarding.md` and `docs/runbooks.md` with local setup, troubleshooting, common runbook commands, and integration test DB helper usage such as `./scripts/intg-test-db.sh up`.

### Testing

- No automated tests were executed as part of this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ddd5bd27288325b935ba1bd2a06e7c)