### PR TITLE
feat(observability): add request ID tracing across all server actions and routes

### DIFF
--- a/__mocks__/next/headers.ts
+++ b/__mocks__/next/headers.ts
@@ -1,0 +1,9 @@
+let _mockHeaders: Map<string, string> = new Map();
+
+export function __setMockHeaders(headers: Map<string, string>) {
+    _mockHeaders = headers;
+}
+
+export async function headers() {
+    return _mockHeaders;
+}

--- a/__tests__/unit/request-id.test.ts
+++ b/__tests__/unit/request-id.test.ts
@@ -1,0 +1,191 @@
+import {describe, expect, test, jest, beforeEach} from "@jest/globals";
+import {__setMockHeaders} from "next/headers";
+
+jest.mock('next/server', () => ({
+    after: (cb: () => void) => { cb(); },
+}));
+
+jest.mock('@/app/_lib/axiom/server', () => ({
+    serverLogger: {
+        flush: jest.fn(),
+        info: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+import {withAction, withRequestId, getRequestId} from "@/app/_lib/actions";
+import {requestIdStorage, getRequestId as getRequestIdDirect} from "@/app/_lib/request-context";
+import {addRequestId} from "@/app/_lib/axiom/formatter";
+
+describe("request-id tracing", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        __setMockHeaders(new Map());
+    });
+
+    describe("getRequestId", () => {
+        test("returns undefined when called outside ALS context", () => {
+            expect(getRequestIdDirect()).toBeUndefined();
+        });
+
+        test("returns the request ID when called inside ALS context", () => {
+            const id = "test-request-id-123";
+            requestIdStorage.run(id, () => {
+                expect(getRequestIdDirect()).toBe(id);
+            });
+        });
+    });
+
+    describe("withAction", () => {
+        test("uses x-request-id from headers when available", async () => {
+            __setMockHeaders(new Map([['x-request-id', 'header-id-abc']]));
+
+            let capturedId: string | undefined;
+            const action = withAction(async () => {
+                capturedId = getRequestId();
+                return {success: "ok"};
+            });
+
+            await action();
+            expect(capturedId).toBe("header-id-abc");
+        });
+
+        test("generates a UUID when x-request-id header is absent", async () => {
+            __setMockHeaders(new Map());
+
+            let capturedId: string | undefined;
+            const action = withAction(async () => {
+                capturedId = getRequestId();
+                return {success: "ok"};
+            });
+
+            await action();
+            expect(capturedId).toBeDefined();
+            expect(capturedId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+        });
+
+        test("attaches requestId to failure responses", async () => {
+            __setMockHeaders(new Map([['x-request-id', 'fail-id-123']]));
+
+            const action = withAction(async () => ({failure: "something went wrong"}));
+            const result = await action();
+
+            expect(result.failure).toBe("something went wrong");
+            expect(result.requestId).toBe("fail-id-123");
+        });
+
+        test("attaches requestId to error responses", async () => {
+            __setMockHeaders(new Map([['x-request-id', 'error-id-456']]));
+
+            const action = withAction(async () => ({errors: {_errors: ["bad input"]}} as any));
+            const result = await action();
+
+            expect(result.errors).toBeDefined();
+            expect(result.requestId).toBe("error-id-456");
+        });
+
+        test("does not attach requestId to success responses", async () => {
+            __setMockHeaders(new Map([['x-request-id', 'success-id-789']]));
+
+            const action = withAction(async () => ({success: "data"}));
+            const result = await action();
+
+            expect(result.success).toBe("data");
+            expect(result.requestId).toBeUndefined();
+        });
+
+        test("passes arguments through to the wrapped function", async () => {
+            const action = withAction(async (a: number, b: string) => {
+                return {success: `${a}-${b}`};
+            });
+
+            const result = await action(42, "hello");
+            expect(result.success).toBe("42-hello");
+        });
+    });
+
+    describe("withRequestId", () => {
+        test("uses x-request-id from headers when available", async () => {
+            __setMockHeaders(new Map([['x-request-id', 'req-id-xyz']]));
+
+            let capturedId: string | undefined;
+            const fn = withRequestId(async () => {
+                capturedId = getRequestId();
+                return "result";
+            });
+
+            await fn();
+            expect(capturedId).toBe("req-id-xyz");
+        });
+
+        test("generates a UUID when x-request-id header is absent", async () => {
+            __setMockHeaders(new Map());
+
+            let capturedId: string | undefined;
+            const fn = withRequestId(async () => {
+                capturedId = getRequestId();
+                return "result";
+            });
+
+            await fn();
+            expect(capturedId).toBeDefined();
+            expect(capturedId).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+        });
+
+        test("returns the original function result unchanged", async () => {
+            __setMockHeaders(new Map([['x-request-id', 'some-id']]));
+
+            const fn = withRequestId(async (x: number) => x * 2);
+            const result = await fn(21);
+            expect(result).toBe(42);
+        });
+
+        test("passes arguments through to the wrapped function", async () => {
+            const fn = withRequestId(async (a: string, b: number) => `${a}:${b}`);
+            const result = await fn("test", 99);
+            expect(result).toBe("test:99");
+        });
+    });
+
+    describe("addRequestId formatter", () => {
+        test("adds requestId field when inside ALS context", () => {
+            const record = {level: "info" as const, message: "test", fields: {existing: "field"}};
+
+            const result = requestIdStorage.run("fmt-id-123", () => {
+                return addRequestId(record);
+            });
+
+            expect(result.fields).toEqual({
+                existing: "field",
+                requestId: "fmt-id-123",
+            });
+        });
+
+        test("returns record unchanged when outside ALS context", () => {
+            const record = {level: "info" as const, message: "test", fields: {existing: "field"}};
+
+            const result = addRequestId(record);
+
+            expect(result).toBe(record);
+            expect(result.fields).toEqual({existing: "field"});
+        });
+
+        test("preserves existing fields when adding requestId", () => {
+            const record = {
+                level: "error" as const,
+                message: "failure",
+                fields: {host: "localhost", code: 500},
+            };
+
+            const result = requestIdStorage.run("preserve-test", () => {
+                return addRequestId(record);
+            });
+
+            expect(result.fields).toEqual({
+                host: "localhost",
+                code: 500,
+                requestId: "preserve-test",
+            });
+        });
+    });
+});

--- a/src/app/(external)/(auth)/register/register-action.ts
+++ b/src/app/(external)/(auth)/register/register-action.ts
@@ -4,7 +4,7 @@ import {registerSchema} from "@/app/_lib/zod/auth/zod";
 import {createUser, findUserByEmail} from "@/app/_db/user";
 import bcrypt from "bcrypt";
 import {PrismaClientKnownRequestError, PrismaClientUnknownRequestError} from "@prisma/client/runtime/library";
-import {after} from "next/server";
+import {withRequestId} from "@/app/_lib/actions";
 import {serverLogger} from "@/app/_lib/axiom/server";
 
 export type ResetUserType = {
@@ -17,10 +17,7 @@ export type ResetUserType = {
     }
 }
 
-export async function registerUser(prevState: ResetUserType, formData: FormData): Promise<ResetUserType> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const registerUser = withRequestId(async (prevState: ResetUserType, formData: FormData): Promise<ResetUserType> => {
     const {success, data, error} = registerSchema.safeParse({
         email: formData.get('email'),
         password: formData.get('password'),
@@ -64,4 +61,4 @@ export async function registerUser(prevState: ResetUserType, formData: FormData)
     }
 
     return { success: "Registrasi berhasil" };
-}
+});

--- a/src/app/(external)/(auth)/reset-request/reset-action.ts
+++ b/src/app/(external)/(auth)/reset-request/reset-action.ts
@@ -7,7 +7,7 @@ import {generateRandomPassword} from "@/app/_lib/util";
 import prisma from "@/app/_lib/primsa";
 import bcrypt from "bcrypt";
 import nodemailerClient, {EMAIL_TEMPLATES, withTemplate} from "@/app/_lib/mailer";
-import {after} from "next/server";
+import {withRequestId} from "@/app/_lib/actions";
 import {serverLogger} from "@/app/_lib/axiom/server";
 
 type ResetPasswordType = {
@@ -18,10 +18,7 @@ type ResetPasswordType = {
     }
 }
 
-export async function resetPasswordAction(prevState: ResetPasswordType, formData: FormData): Promise<ResetPasswordType> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const resetPasswordAction = withRequestId(async (prevState: ResetPasswordType, formData: FormData): Promise<ResetPasswordType> => {
     const {success, data, error} = resetSchema.safeParse({
         email: formData.get('email'),
     });
@@ -82,4 +79,4 @@ export async function resetPasswordAction(prevState: ResetPasswordType, formData
     }
 
     return {success: "Jika terdapat akun yang terdaftar dengan alamat email ini, tautan untuk mengatur ulang kata sandi telah dikirim. Silakan periksa email Anda dan ikuti instruksi yang diberikan."};
-}
+});

--- a/src/app/(internal)/(dashboard_layout)/addons/addons-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/addons/addons-action.ts
@@ -7,7 +7,7 @@ import {object, string} from "zod";
 import {PrismaClientKnownRequestError, PrismaClientUnknownRequestError} from "@prisma/client/runtime/library";
 import {AddonSchema} from "@/app/_lib/zod/addon/zod";
 import {serverLogger} from "@/app/_lib/axiom/server";
-import {after} from "next/server";
+import {withAction} from "@/app/_lib/actions";
 import {serializeForClient} from "@/app/_lib/util/prisma";
 
 const toClient = <T>(value: T) => serializeForClient(value);
@@ -30,10 +30,7 @@ export type AddonIncludePricing = Prisma.AddOnGetPayload<{
     activeBookingsCount: number
 };
 
-export async function upsertAddonAction(reqData: OmitIDTypeAndTimestamp<AddOn>) {
-    after(() => {
-        serverLogger.flush();
-    });
+export const upsertAddonAction = withAction(async (reqData: OmitIDTypeAndTimestamp<AddOn>) => {
     const {success, data, error} = AddonSchema.safeParse(reqData);
 
     if (!success) {
@@ -136,12 +133,9 @@ export async function upsertAddonAction(reqData: OmitIDTypeAndTimestamp<AddOn>) 
 
         return toClient({failure: "Request unsuccessful"});
     }
-}
+});
 
-export async function deleteAddOnAction(id: string) {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deleteAddOnAction = withAction(async (id: string) => {
     const parsedData = object({id: string().uuid()}).safeParse({
         id: id,
     });
@@ -168,8 +162,7 @@ export async function deleteAddOnAction(id: string) {
             failure: "Error deleting addon",
         });
     }
-
-}
+});
 
 export async function getAddonsByLocation(id?: number) {
     const addons = await prisma.addOn.findMany({

--- a/src/app/(internal)/(dashboard_layout)/bills/bill-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/bills/bill-action.ts
@@ -19,10 +19,9 @@ import {number, object} from "zod";
 import nodemailerClient, {EMAIL_TEMPLATES, withTemplate} from "@/app/_lib/mailer";
 import {formatToDateTime, formatToIDR} from "@/app/_lib/util";
 import {UpsertBookingPayload} from "@/app/(internal)/(dashboard_layout)/bookings/booking-action";
-import {after} from 'next/server';
 import {serverLogger} from "@/app/_lib/axiom/server";
 import {serializeForClient} from "@/app/_lib/util/prisma";
-import {GenericActionsType} from "@/app/_lib/actions";
+import {GenericActionsType, withAction} from "@/app/_lib/actions";
 import BillUncheckedCreateInput = Prisma.BillUncheckedCreateInput;
 import BillItemUncheckedCreateInput = Prisma.BillItemUncheckedCreateInput;
 
@@ -343,7 +342,7 @@ export async function getAllBillsIncludeAll(id?: number, locationID?: number, li
  * @param billData - Bill data to create or update
  * @returns Success response with bill data or error information
  */
-export async function upsertBillAction(billData: PartialBy<OmitTimestamp<Bill>, "id">) {
+export const upsertBillAction = withAction(async (billData: PartialBy<OmitTimestamp<Bill>, "id">) => {
     const {success, data, error} = billSchemaWithOptionalID.safeParse(billData);
 
     if (!success) {
@@ -351,10 +350,6 @@ export async function upsertBillAction(billData: PartialBy<OmitTimestamp<Bill>, 
             errors: error?.format()
         });
     }
-
-    after(() => {
-        serverLogger.flush();
-    });
 
     try {
         let res;
@@ -407,27 +402,23 @@ export async function upsertBillAction(billData: PartialBy<OmitTimestamp<Bill>, 
 
         return toClient({failure: "Request unsuccessful"});
     }
-}
+});
 
 /**
  * Deletes a bill by ID
  * @param id - The bill ID to delete
  * @returns Success response with deleted bill data or error information
  */
-export async function deleteBillAction(id: number) {
+export const deleteBillAction = withAction(async (id: number) => {
     const {success, error, data} = object({id: number().positive()}).safeParse({
         id: id
     });
 
     if (!success) {
         return toClient({
-            errors: error?.flatten()
+            errors: error?.format()
         });
     }
-
-    after(() => {
-        serverLogger.flush();
-    });
 
     try {
         let res = await prisma.bill.delete({
@@ -445,7 +436,7 @@ export async function deleteBillAction(id: number) {
             failure: "error"
         });
     }
-}
+});
 
 /**
  * Synchronizes payment-bill records for a booking based on payment dates
@@ -532,10 +523,10 @@ export async function getUpcomingUnpaidBillsWithUsersByDate(targetDate: Date, li
  * @param billID - The bill ID to send reminder for
  * @returns Success or failure response
  */
-export async function sendBillEmailAction(billID: number): Promise<
+export const sendBillEmailAction = withAction(async (billID: number): Promise<
     | { success: string; failure?: never }
     | { failure: string; success?: never }
-> {
+> => {
     let billData = await prisma.bill.findFirst({
         where: {
             id: billID
@@ -555,10 +546,6 @@ export async function sendBillEmailAction(billID: number): Promise<
             failure: "Bill Not Found"
         });
     }
-
-    after(() => {
-        serverLogger.flush();
-    });
 
     const tenant = billData.bookings.tenants!;
     const currBillAmount = billData.bill_item.reduce(
@@ -589,8 +576,7 @@ export async function sendBillEmailAction(billID: number): Promise<
     return toClient({
         success: "Email Sent Successfully."
     });
-
-}
+});
 
 /**
  * Generates bill items for booking add-ons and maps them to bills by due date
@@ -994,12 +980,12 @@ type BillItemReturnType = {
  * @param billItemData - Bill item data to update
  * @returns Success response with updated bill item data or error information
  */
-export async function updateBillItemAction(billItemData: {
+export const updateBillItemAction = withAction(async (billItemData: {
     id: number;
     description?: string;
     amount?: number;
     internal_description?: string;
-}): Promise<GenericActionsType<BillItemReturnType>> {
+}): Promise<GenericActionsType<BillItemReturnType>> => {
     const {success, data, error} = billItemUpdateSchema.safeParse(billItemData);
 
     if (!success) {
@@ -1007,10 +993,6 @@ export async function updateBillItemAction(billItemData: {
             errors: error?.format()
         });
     }
-
-    after(() => {
-        serverLogger.flush();
-    });
 
     try {
         const res = await prisma.$transaction(async (tx) => {
@@ -1051,17 +1033,14 @@ export async function updateBillItemAction(billItemData: {
 
         return toClient({failure: "Gagal memperbarui rincian tagihan"});
     }
-}
+});
 
 /**
  * Deletes a bill item
  * @param id - The bill item ID to delete
  * @returns Success response with deleted bill item data or error information
  */
-export async function deleteBillItemAction(id: number): Promise<GenericActionsType<BillItemReturnType>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deleteBillItemAction = withAction(async (id: number): Promise<GenericActionsType<BillItemReturnType>> => {
 
     try {
         const res = await prisma.$transaction(async (tx) => {
@@ -1107,20 +1086,20 @@ export async function deleteBillItemAction(id: number): Promise<GenericActionsTy
 
         return toClient({failure: "Gagal menghapus rincian tagihan"});
     }
-}
+});
 
 /**
  * Creates a new bill item
  * @param billItemData - Bill item data to create
  * @returns Success response with created bill item data or error information
  */
-export async function createBillItemAction(billItemData: {
+export const createBillItemAction = withAction(async (billItemData: {
     bill_id: number;
     description: string;
     amount: number;
     internal_description?: string;
     type?: BillType;
-}): Promise<GenericActionsType<BillItemReturnType>> {
+}): Promise<GenericActionsType<BillItemReturnType>> => {
     const {success, data, error} = billItemCreateSchema.safeParse(billItemData);
 
     if (!success) {
@@ -1128,10 +1107,6 @@ export async function createBillItemAction(billItemData: {
             errors: error?.format()
         });
     }
-
-    after(() => {
-        serverLogger.flush();
-    });
 
     try {
         const res = await prisma.$transaction(async (tx) => {
@@ -1173,4 +1148,4 @@ export async function createBillItemAction(billItemData: {
 
         return toClient({failure: "Gagal membuat rincian tagihan"});
     }
-}
+});

--- a/src/app/(internal)/(dashboard_layout)/bills/content.tsx
+++ b/src/app/(internal)/(dashboard_layout)/bills/content.tsx
@@ -28,6 +28,7 @@ import {
     Typography
 } from "@material-tailwind/react";
 import {useMutation, UseMutationResult} from "@tanstack/react-query";
+import {GenericActionsType} from "@/app/_lib/actions";
 import {MdClose, MdDelete, MdEdit, MdEmail, MdSave} from "react-icons/md";
 import {toast} from "react-toastify";
 import {BillPageQueryParams} from "@/app/(internal)/(dashboard_layout)/bills/page";
@@ -782,10 +783,7 @@ const DetailsDialogContent = ({activeData, setShowDialog, onBillUpdate}: {
 
 const EmailConfirmationDialog = ({activeData, sendBillEmailMutation, setShowDialog}: {
     activeData: BillIncludeBookingAndPayments;
-    sendBillEmailMutation: UseMutationResult<{ failure: string, success?: undefined } | {
-        success: string,
-        failure?: undefined
-    }, Error, number, unknown>
+    sendBillEmailMutation: UseMutationResult<GenericActionsType<string>, Error, number, unknown>
     setShowDialog: React.Dispatch<React.SetStateAction<boolean>>
 }) => {
     return (

--- a/src/app/(internal)/(dashboard_layout)/bookings/booking-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/bookings/booking-action.ts
@@ -27,7 +27,7 @@ import {
     updateBookingByID
 } from "@/app/_db/bookings";
 import {PrismaClientKnownRequestError, PrismaClientUnknownRequestError} from "@prisma/client/runtime/library";
-import {GenericActionsType} from "@/app/_lib/actions";
+import {GenericActionsType, withAction} from "@/app/_lib/actions";
 import {CheckInOutType} from "@/app/(internal)/(dashboard_layout)/bookings/enum";
 import {updateDepositStatus} from "@/app/_db/deposit";
 import {revalidateTag} from "next/cache";
@@ -44,7 +44,6 @@ import {
     subDays
 } from "date-fns";
 import {id as indonesianLocale} from "date-fns/locale";
-import {after} from "next/server";
 import {serverLogger} from "@/app/_lib/axiom/server";
 import {serializeForClient} from "@/app/_lib/util/prisma";
 import BillItemUncheckedCreateWithoutBillInput = Prisma.BillItemUncheckedCreateWithoutBillInput;
@@ -127,7 +126,7 @@ function processAddonsForPeriod(
 
 export type UpsertBookingPayload = OmitTimestamp<BookingsIncludeAll>
 
-export async function upsertBookingAction(reqData: UpsertBookingPayload): Promise<GenericActionsType<Booking>> {
+export const upsertBookingAction = withAction(async (reqData: UpsertBookingPayload): Promise<GenericActionsType<Booking>> => {
     const {success, data, error} = bookingSchema.safeParse(reqData);
 
     if (!success) {
@@ -135,10 +134,6 @@ export async function upsertBookingAction(reqData: UpsertBookingPayload): Promis
             errors: error?.format()
         });
     }
-
-    after(() => {
-        serverLogger.flush();
-    });
 
     // Handle rolling bookings
     if (data.is_rolling) {
@@ -551,7 +546,7 @@ export async function upsertBookingAction(reqData: UpsertBookingPayload): Promis
 
         return toClient({failure: "Request unsuccessful"});
     }
-}
+});
 
 export async function getAllBookingsAction(...args: Parameters<typeof getAllBookings>) {
     return getAllBookings(...args).then(toClient);
@@ -561,10 +556,7 @@ export async function getBookingsWithUnpaidBillsAction(...args: Parameters<typeo
     return getBookingsWithUnpaidBills(...args).then(toClient);
 }
 
-export async function deleteBookingAction(id: number) {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deleteBookingAction = withAction(async (id: number) => {
     const parsedData = object({id: number().positive()}).safeParse({
         id: id,
     });
@@ -591,16 +583,15 @@ export async function deleteBookingAction(id: number) {
             failure: "Error deleting booking",
         });
     }
+});
 
-}
-
-export async function checkInOutAction(data: {
+export const checkInOutAction = withAction(async (data: {
     booking_id: number,
     action: CheckInOutType,
     depositStatus?: string,
     refundedAmount?: number,
     eventDate?: Date
-}): Promise<GenericActionsType<CheckInOutLog>> {
+}): Promise<GenericActionsType<CheckInOutLog>> => {
     const booking = await prisma.booking.findFirst({
         where: {
             id: data.booking_id
@@ -672,15 +663,12 @@ export async function checkInOutAction(data: {
             success: checkInOutLog
         };
     }).then(toClient);
-}
+});
 
 export async function matchBillItemsToBills(
     billItemsByDueDate: Map<Date, Omit<BillItem, "bill_id">[]>,
     bills: Pick<Bill, "due_date" | "id">[]
 ): Promise<Map<number, Omit<BillItem, "bill_id">[]>> {
-    after(() => {
-        serverLogger.flush();
-    });
     // Sort bills by due_date for easier matching
     const sortedBills = bills.sort((a, b) => a.due_date.getTime() - b.due_date.getTime());
 
@@ -725,10 +713,10 @@ export async function matchBillItemsToBills(
  * @param data - An object containing the bookingId and endDate.
  * @returns A success or failure response.
  */
-export async function scheduleEndOfStayAction(data: {
+export const scheduleEndOfStayAction = withAction(async (data: {
     bookingId: number;
     endDate: Date;
-}): Promise<GenericActionsType<boolean>> {
+}): Promise<GenericActionsType<boolean>> => {
     const {bookingId, endDate} = data;
 
     const booking = await prisma.booking.findFirst({
@@ -763,7 +751,7 @@ export async function scheduleEndOfStayAction(data: {
     } catch (error) {
         return toClient({failure: "Gagal memperbarui pemesanan."});
     }
-}
+});
 
 /**
  * Generates the initial set of bills for a new rolling booking.
@@ -858,9 +846,6 @@ export async function generateInitialBillsForRollingBooking(booking: Pick<Bookin
  * @returns The new bill object if one was created, otherwise null.
  */
 export async function generateNextMonthlyBill(booking: BookingIncludeAddons, existingBills: Bill[], date: Date): Promise<Prisma.BillCreateInput | null> {
-    after(() => {
-        serverLogger.flush();
-    });
 
     if (existingBills.length === 0) {
         return null;
@@ -988,11 +973,11 @@ async function cleanupInvalidBills(bookingId: number, endDate: Date, tx: Prisma.
  * @param data - An object containing the bookingId, addonId, and endDate.
  * @returns A success or failure response.
  */
-export async function scheduleEndOfAddonAction(data: {
+export const scheduleEndOfAddonAction = withAction(async (data: {
     bookingId: number;
     addonId: string;
     endDate: Date;
-}): Promise<GenericActionsType<boolean>> {
+}): Promise<GenericActionsType<boolean>> => {
     const {bookingId, addonId, endDate} = data;
 
     const bookingAddon = await prisma.bookingAddOn.findFirst({
@@ -1040,4 +1025,4 @@ export async function scheduleEndOfAddonAction(data: {
     } catch (error) {
         return toClient({failure: "Gagal memperbarui layanan tambahan."});
     }
-}
+});

--- a/src/app/(internal)/(dashboard_layout)/data-center/locations/location-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/data-center/locations/location-action.ts
@@ -5,7 +5,7 @@ import {number, object, typeToFlattenedError} from "zod";
 import {OmitIDTypeAndTimestamp, OmitTimestamp} from "@/app/_db/db";
 import {Location} from "@prisma/client";
 import {createLocation, deleteLocation, getLocations, updateLocationByID, upsertLocation} from "@/app/_db/location";
-import {after} from "next/server";
+import {withRequestId} from "@/app/_lib/actions";
 import {serverLogger} from "@/app/_lib/axiom/server";
 import {serializeForClient} from "@/app/_lib/util/prisma";
 
@@ -17,10 +17,7 @@ export type LocationActionsType<T = OmitIDTypeAndTimestamp<Location>> = {
     errors?: typeToFlattenedError<T>
 }
 
-export async function createLocationAction(prevState: LocationActionsType, formData: FormData): Promise<LocationActionsType> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const createLocationAction = withRequestId(async (prevState: LocationActionsType, formData: FormData): Promise<LocationActionsType> => {
     const { success, error, data } = locationObject.safeParse({
         name: formData.get('name'),
         address: formData.get('address'),
@@ -45,12 +42,9 @@ export async function createLocationAction(prevState: LocationActionsType, formD
             failure: "error"
         });
     }
-}
+});
 
-export async function updateLocationAction(prevState: LocationActionsType, formData: FormData): Promise<LocationActionsType> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const updateLocationAction = withRequestId(async (prevState: LocationActionsType, formData: FormData): Promise<LocationActionsType> => {
     let { success, error, data } = locationObjectWithID.safeParse({
         id: formData.get('id'),
         name: formData.get('name'),
@@ -80,12 +74,9 @@ export async function updateLocationAction(prevState: LocationActionsType, formD
             failure: "error"
         });
     }
-}
+});
 
-export async function upsertLocationAction(locationData: OmitTimestamp<Location>): Promise<LocationActionsType> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const upsertLocationAction = withRequestId(async (locationData: OmitTimestamp<Location>): Promise<LocationActionsType> => {
     const {success, error, data} = locationObjectWithOptionalID.safeParse(locationData);
 
     if (!success) {
@@ -107,7 +98,7 @@ export async function upsertLocationAction(locationData: OmitTimestamp<Location>
             failure: "error"
         });
     }
-}
+});
 
 export async function deleteLocationAction(id: number): Promise<LocationActionsType<Pick<Location, "id">>> {
     const { success, error, data } = object({ id: number().positive() }).safeParse({

--- a/src/app/(internal)/(dashboard_layout)/data-center/penalties/penalties-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/data-center/penalties/penalties-action.ts
@@ -3,7 +3,7 @@ import {OmitIDTypeAndTimestamp} from "@/app/_db/db";
 import {createPenalty, deletePenalty, updatePenaltyByID} from "@/app/_db/penalty";
 import {number, object} from "zod";
 import {penaltySchema, penaltySchemaWithID} from "@/app/_lib/zod/penalties/zod";
-import {after} from "next/server";
+import {withRequestId} from "@/app/_lib/actions";
 import {serverLogger} from "@/app/_lib/axiom/server";
 
 export type PenaltyActionsType<T = OmitIDTypeAndTimestamp<Penalty>> = {
@@ -12,10 +12,7 @@ export type PenaltyActionsType<T = OmitIDTypeAndTimestamp<Penalty>> = {
     errors?: Partial<Penalty>;
 };
 
-export async function createPenaltyAction(prevState: PenaltyActionsType, formData: FormData): Promise<PenaltyActionsType> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const createPenaltyAction = withRequestId(async (prevState: PenaltyActionsType, formData: FormData): Promise<PenaltyActionsType> => {
     const parsedData = penaltySchema.safeParse({
         amount: parseFloat(formData.get("amount") as string),
         description: formData.get("description"),
@@ -45,12 +42,9 @@ export async function createPenaltyAction(prevState: PenaltyActionsType, formDat
             failure: "Error creating penalty",
         };
     }
-}
+});
 
-export async function updatePenaltyAction(prevState: PenaltyActionsType, formData: FormData): Promise<PenaltyActionsType> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const updatePenaltyAction = withRequestId(async (prevState: PenaltyActionsType, formData: FormData): Promise<PenaltyActionsType> => {
     const parsedData = penaltySchemaWithID.safeParse({
         id: parseInt(formData.get("id") as string),
         amount: parseFloat(formData.get("amount") as string),
@@ -81,12 +75,9 @@ export async function updatePenaltyAction(prevState: PenaltyActionsType, formDat
             failure: "Error updating penalty",
         };
     }
-}
+});
 
-export async function deletePenaltyAction(prevState: PenaltyActionsType<Pick<Penalty, "id">>, formData: FormData): Promise<PenaltyActionsType<Pick<Penalty, "id">>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deletePenaltyAction = withRequestId(async (prevState: PenaltyActionsType<Pick<Penalty, "id">>, formData: FormData): Promise<PenaltyActionsType<Pick<Penalty, "id">>> => {
     const parsedData = object({ id: number().positive() }).safeParse({
         id: parseInt(formData.get("id") as string),
     });
@@ -110,4 +101,4 @@ export async function deletePenaltyAction(prevState: PenaltyActionsType<Pick<Pen
             failure: "Error deleting penalty",
         };
     }
-}
+});

--- a/src/app/(internal)/(dashboard_layout)/deposits/deposit-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/deposits/deposit-action.ts
@@ -4,10 +4,9 @@ import {Deposit, DepositStatus, Prisma} from "@prisma/client";
 import {number, object} from "zod";
 import {createDeposit, deleteDeposit, getAllDeposits, updateDeposit, updateDepositStatus,} from "@/app/_db/deposit";
 import {PrismaClientKnownRequestError, PrismaClientUnknownRequestError} from "@prisma/client/runtime/library";
-import {GenericActionsType} from "@/app/_lib/actions";
+import {GenericActionsType, withAction, withRequestId} from "@/app/_lib/actions";
 import {depositSchema, updateDepositStatusSchema} from "@/app/_lib/zod/deposit/zod";
 import prisma from "@/app/_lib/primsa";
-import {after} from "next/server";
 import {serverLogger} from "@/app/_lib/axiom/server";
 import {serializeForClient} from "@/app/_lib/util/prisma";
 
@@ -21,10 +20,7 @@ export type UpsertDepositPayload = {
     refunded_amount?: Prisma.Decimal | string | number | null;
 };
 
-export async function upsertDepositAction(reqData: UpsertDepositPayload): Promise<GenericActionsType<Deposit>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const upsertDepositAction = withAction(async (reqData: UpsertDepositPayload): Promise<GenericActionsType<Deposit>> => {
     const {success, data, error} = depositSchema.safeParse(reqData);
 
     if (!success) {
@@ -82,24 +78,18 @@ export async function upsertDepositAction(reqData: UpsertDepositPayload): Promis
 
         return toClient({failure: "Permintaan tidak berhasil"});
     }
-}
+});
 
-export async function getAllDepositsAction() {
-    after(() => {
-        serverLogger.flush();
-    });
+export const getAllDepositsAction = withRequestId(async () => {
     try {
         return toClient(await getAllDeposits());
     } catch (error) {
         serverLogger.error("[getAllDepositsAction]", {error});
         throw error;
     }
-}
+});
 
-export async function deleteDepositAction(id: number): Promise<GenericActionsType<Deposit>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deleteDepositAction = withAction(async (id: number): Promise<GenericActionsType<Deposit>> => {
     const parsedData = object({id: number().positive()}).safeParse({id});
 
     if (!parsedData.success) {
@@ -119,16 +109,13 @@ export async function deleteDepositAction(id: number): Promise<GenericActionsTyp
             failure: "Gagal menghapus deposit",
         });
     }
-}
+});
 
-export async function updateDepositStatusAction(data: {
+export const updateDepositStatusAction = withAction(async (data: {
     depositId: number;
     newStatus: DepositStatus;
     refundedAmount?: Prisma.Decimal | number;
-}): Promise<GenericActionsType<Deposit>> {
-    after(() => {
-        serverLogger.flush();
-    });
+}): Promise<GenericActionsType<Deposit>> => {
     const validation = updateDepositStatusSchema.safeParse({
         id: data.depositId,
         status: data.newStatus,
@@ -157,4 +144,4 @@ export async function updateDepositStatusAction(data: {
             failure: error instanceof Error ? error.message : "Gagal memperbarui status deposit"
         });
     }
-}
+});

--- a/src/app/(internal)/(dashboard_layout)/financials/transaction-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/financials/transaction-action.ts
@@ -2,9 +2,8 @@
 
 import {transactionSchema} from "@/app/_lib/zod/transaction/zod";
 import {DepositStatus, Prisma, Transaction} from "@prisma/client";
-import {GenericActionsType} from "@/app/_lib/actions";
+import {GenericActionsType, withAction} from "@/app/_lib/actions";
 import prisma from "@/app/_lib/primsa";
-import {after} from "next/server";
 import {serverLogger} from "@/app/_lib/axiom/server";
 import {serializeForClient} from "@/app/_lib/util/prisma";
 import {getTransactionsWithBookingInfo} from "@/app/_db/transaction";
@@ -15,12 +14,9 @@ const toClient = <T>(value: T) => serializeForClient(value);
  * Creates or Updates a transaction based on the presence of an ID.
  * @param transactionData The transaction data object.
  */
-export async function upsertTransactionAction(
+export const upsertTransactionAction = withAction(async (
     transactionData: Partial<Transaction>
-): Promise<GenericActionsType<Transaction>> {
-    after(() => {
-        serverLogger.flush();
-    });
+): Promise<GenericActionsType<Transaction>> => {
     const { success, data, error } = transactionSchema.safeParse(transactionData);
 
     if (!success) {
@@ -68,13 +64,10 @@ export async function upsertTransactionAction(
             failure: 'An error occurred while processing the transaction.',
         });
     }
-}
+});
 
 // Action to delete a Transaction
-export async function deleteTransactionAction(id: number): Promise<GenericActionsType<Transaction>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deleteTransactionAction = withAction(async (id: number): Promise<GenericActionsType<Transaction>> => {
     try {
         const res = await prisma.$transaction(async (tx) => {
             let deletedTransaction = await tx.transaction.delete({
@@ -111,7 +104,7 @@ export async function deleteTransactionAction(id: number): Promise<GenericAction
         serverLogger.error("[deleteTransactionAction]", {error, transaction_id: id});
         return toClient({ failure: "Error deleting transaction" });
     }
-}
+});
 
 export async function getTransactionsWithBookingInfoAction(
     ...args: Parameters<typeof getTransactionsWithBookingInfo>

--- a/src/app/(internal)/(dashboard_layout)/payments/payment-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/payments/payment-action.ts
@@ -13,10 +13,9 @@ import {
 } from "@/app/(internal)/(dashboard_layout)/bills/bill-action";
 import {DeleteObjectCommand, PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
 import {getBookingByID} from "@/app/_db/bookings";
-import {after} from "next/server";
 import {serverLogger} from "@/app/_lib/axiom/server";
 import {serializeForClient} from "@/app/_lib/util/prisma";
-import {GenericActionsType} from "@/app/_lib/actions";
+import {GenericActionsType, withAction} from "@/app/_lib/actions";
 
 const toClient = <T>(value: T) => serializeForClient(value);
 
@@ -47,13 +46,10 @@ export async function createPaymentBillsFromBillAllocations(
     }
 }
 
-export async function upsertPaymentAction(reqData: OmitIDTypeAndTimestamp<Payment> & {
+export const upsertPaymentAction = withAction(async (reqData: OmitIDTypeAndTimestamp<Payment> & {
     allocationMode?: 'auto' | 'manual',
     manualAllocations?: Record<number, number>
-}): Promise<GenericActionsType<Booking>> {
-    after(() => {
-        serverLogger.flush();
-    });
+}): Promise<GenericActionsType<Booking>> => {
     const {success, data, error} = paymentSchema.safeParse(reqData);
 
     if (!success) {
@@ -188,12 +184,9 @@ export async function upsertPaymentAction(reqData: OmitIDTypeAndTimestamp<Paymen
     return toClient({
         failure: trxRes.error
     });
-}
+});
 
-export async function deletePaymentAction(id: number): Promise<GenericActionsType<Payment>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deletePaymentAction = withAction(async (id: number): Promise<GenericActionsType<Payment>> => {
     const parsedData = object({id: number().positive()}).safeParse({
         id: id,
     });
@@ -255,8 +248,7 @@ export async function deletePaymentAction(id: number): Promise<GenericActionsTyp
             failure: "Error deleting payment",
         });
     }
-
-}
+});
 
 export async function getPaymentStatusAction() {
     return getPaymentStatus().then(toClient);

--- a/src/app/(internal)/(dashboard_layout)/residents/guests/guest-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/residents/guests/guest-action.ts
@@ -2,23 +2,19 @@
 
 import {Guest, GuestStay, Prisma} from "@prisma/client";
 import {PrismaClientKnownRequestError, PrismaClientUnknownRequestError} from "@prisma/client/runtime/library";
-import {GenericActionsType} from "@/app/_lib/actions";
+import {GenericActionsType, withAction} from "@/app/_lib/actions";
 import {number, object} from "zod";
 import {guestSchemaWithOptionalID, guestStaySchema} from "@/app/_lib/zod/guests/zod";
 import {createGuest, deleteGuest, GuestIncludeAll, updateGuestByID} from "@/app/_db/guest";
 import prisma from "@/app/_lib/primsa";
 import {PartialBy} from "@/app/_db/db";
-import {after} from "next/server";
 import {serverLogger} from "@/app/_lib/axiom/server";
 import {serializeForClient} from "@/app/_lib/util/prisma";
 
 const toClient = <T>(value: T) => serializeForClient(value);
 
 // Action to update guests
-export async function upsertGuestAction(guestData: Partial<Guest>): Promise<GenericActionsType<GuestIncludeAll>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const upsertGuestAction = withAction(async (guestData: Partial<Guest>): Promise<GenericActionsType<GuestIncludeAll>> => {
     const {success, data, error} = guestSchemaWithOptionalID.safeParse(guestData);
 
     if (!success) {
@@ -51,12 +47,9 @@ export async function upsertGuestAction(guestData: Partial<Guest>): Promise<Gene
 
         return toClient({failure: "Request unsuccessful"});
     }
-}
+});
 
-export async function deleteGuestAction(id: string): Promise<GenericActionsType<GuestIncludeAll>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deleteGuestAction = withAction(async (id: string): Promise<GenericActionsType<GuestIncludeAll>> => {
     const parsedData = object({id: number().positive()}).safeParse({
         id: id,
     });
@@ -78,14 +71,11 @@ export async function deleteGuestAction(id: string): Promise<GenericActionsType<
             failure: "Error deleting guest",
         });
     }
-}
+});
 
 
 // Action to Create or Update Guest Stay
-export async function upsertGuestStayAction(guestStayData: Partial<GuestStay>): Promise<GenericActionsType<any>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const upsertGuestStayAction = withAction(async (guestStayData: Partial<GuestStay>): Promise<GenericActionsType<any>> => {
     const {success, data, error} = guestStaySchema.safeParse(guestStayData);
 
     if (!success) {
@@ -200,13 +190,10 @@ export async function upsertGuestStayAction(guestStayData: Partial<GuestStay>): 
         serverLogger.error("[upsertGuestStayAction]", {error});
         return toClient({failure: "Error processing guest stay."});
     }
-}
+});
 
 // Action to Delete Guest Stay
-export async function deleteGuestStayAction(id: number): Promise<GenericActionsType<GuestStay>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deleteGuestStayAction = withAction(async (id: number): Promise<GenericActionsType<GuestStay>> => {
     const parsedData = object({id: number().positive()}).safeParse({id});
 
     if (!parsedData.success) {
@@ -253,7 +240,7 @@ export async function deleteGuestStayAction(id: number): Promise<GenericActionsT
         serverLogger.error("[deleteGuestStayAction]", {error, guest_stay_id: id});
         return toClient({failure: "Error deleting guest stay."});
     }
-}
+});
 
 type GuestStayWithMonthlyFee = GuestStay & {
     total_fee: Prisma.Decimal

--- a/src/app/(internal)/(dashboard_layout)/residents/tenants/form.tsx
+++ b/src/app/(internal)/(dashboard_layout)/residents/tenants/form.tsx
@@ -611,7 +611,7 @@ export function TenantForm(props: TenantFormProps) {
                                             <input type="file" accept="image/png, image/jpg, image/jpeg, image/webp"
                                                    onChange={(e) => {
                                                        const file = e.target.files?.[0];
-                                                       if (file?.size && file?.size > 5120000) {
+                                                       if (file?.size && file?.size > 3072000) {
                                                            toast.error("Ukuran Gambar Terlalu Besar");
                                                            e.target.value = "";
                                                        } else {
@@ -621,7 +621,7 @@ export function TenantForm(props: TenantFormProps) {
                                                    className="w-full font-semibold text-sm bg-white border file:cursor-pointer cursor-pointer file:border-0 file:py-3 file:px-4 file:mr-4 file:bg-gray-100 file:hover:bg-gray-200 file:text-gray-500 rounded"/>
                                             <p className="text-xs mt-2">PNG, JPG, JPEG, WEBP diperbolehkan. Ukuran
                                                 maksimum
-                                                gambar adalah 5MB</p>
+                                                gambar adalah 3MB</p>
                                             {
                                                 fieldErrors?.family_certificate_file_data &&
                                                 // @ts-expect-error weird react 19 types error

--- a/src/app/(internal)/(dashboard_layout)/residents/tenants/tenant-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/residents/tenants/tenant-action.ts
@@ -2,7 +2,7 @@
 
 import {Tenant} from "@prisma/client";
 import {PrismaClientKnownRequestError} from "@prisma/client/runtime/library";
-import {GenericActionsType} from "@/app/_lib/actions";
+import {GenericActionsType, withAction} from "@/app/_lib/actions";
 import {object, string} from "zod";
 import {
     createTenant,
@@ -16,17 +16,13 @@ import {tenantSchemaWithOptionalID} from "@/app/_lib/zod/tenant/zod";
 import {DeleteObjectCommand, DeleteObjectsCommand, PutObjectCommand, S3Client} from "@aws-sdk/client-s3";
 import {OmitTimestamp, PartialBy} from "@/app/_db/db";
 import prisma from "@/app/_lib/primsa";
-import {after} from "next/server";
 import {serverLogger} from "@/app/_lib/axiom/server";
 import {serializeForClient} from "@/app/_lib/util/prisma";
 
 const toClient = <T>(value: T) => serializeForClient(value);
 
 // Action to update tenants
-export async function upsertTenantAction(tenantData: Partial<Tenant>): Promise<GenericActionsType<TenantWithRoomsAndSecondResident>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const upsertTenantAction = withAction(async (tenantData: Partial<Tenant>): Promise<GenericActionsType<TenantWithRoomsAndSecondResident>> => {
     const {success, data, error} = tenantSchemaWithOptionalID.safeParse(tenantData);
 
     if (!success) {
@@ -211,12 +207,9 @@ export async function upsertTenantAction(tenantData: Partial<Tenant>): Promise<G
 
         return toClient({failure: "Request unsuccessful"});
     }
-}
+});
 
-export async function deleteTenantAction(id: string): Promise<GenericActionsType<TenantWithRooms>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deleteTenantAction = withAction(async (id: string): Promise<GenericActionsType<TenantWithRooms>> => {
     const parsedData = object({id: string().min(1, "ID is required")}).safeParse({
         id: id,
     });
@@ -238,7 +231,7 @@ export async function deleteTenantAction(id: string): Promise<GenericActionsType
             failure: "Error deleting tenant",
         });
     }
-}
+});
 
 export async function getTenantsWithRoomsAction(
     ...args: Parameters<typeof getTenantsWithRooms>

--- a/src/app/(internal)/(dashboard_layout)/rooms/durations/duration-actions.ts
+++ b/src/app/(internal)/(dashboard_layout)/rooms/durations/duration-actions.ts
@@ -2,21 +2,17 @@
 
 import {Duration} from "@prisma/client";
 import {PrismaClientKnownRequestError, PrismaClientUnknownRequestError} from "@prisma/client/runtime/library";
-import {GenericActionsType} from "@/app/_lib/actions";
+import {GenericActionsType, withAction} from "@/app/_lib/actions";
 import {number, object, ZodIssueCode} from "zod";
 import {durationSchemaWithOptionalID} from "@/app/_lib/zod/duration/zod";
 import {createDuration, deleteDuration, getSortedDurations, updateDurationByID} from "@/app/_db/duration";
 import {IntersectionToUnion} from "@/app/_lib/util";
-import {after} from "next/server";
 import {serverLogger} from "@/app/_lib/axiom/server";
 import {serializeForClient} from "@/app/_lib/util/prisma";
 
 const toClient = <T>(value: T) => serializeForClient(value);
 
-export async function upsertDurationAction(roomData: Partial<Duration>): Promise<GenericActionsType<Duration>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const upsertDurationAction = withAction(async (roomData: Partial<Duration>): Promise<GenericActionsType<Duration>> => {
     const {success, data, error} = durationSchemaWithOptionalID.safeParse(roomData);
 
     if (!success) {
@@ -60,12 +56,9 @@ export async function upsertDurationAction(roomData: Partial<Duration>): Promise
 
         return toClient({failure: "Request unsuccessful"});
     }
-}
+});
 
-export async function deleteDurationAction(id: string): Promise<GenericActionsType<Duration>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deleteDurationAction = withAction(async (id: string): Promise<GenericActionsType<Duration>> => {
     const parsedData = object({id: number().positive()}).safeParse({
         id: id,
     });
@@ -94,7 +87,7 @@ export async function deleteDurationAction(id: string): Promise<GenericActionsTy
 
         return toClient({failure: "Request unsuccessful"});
     }
-}
+});
 
 export async function getSortedDurationsAction() {
     return getSortedDurations().then(toClient);

--- a/src/app/(internal)/(dashboard_layout)/rooms/room-actions.ts
+++ b/src/app/(internal)/(dashboard_layout)/rooms/room-actions.ts
@@ -3,18 +3,14 @@
 import {PrismaClientKnownRequestError, PrismaClientUnknownRequestError} from "@prisma/client/runtime/library";
 import {roomWithType} from "@/app/_lib/zod/rooms/zod";
 import {createRoom, deleteRoom, getRoomsWithBookings, RoomsWithTypeAndLocation, updateRoomByID} from "@/app/_db/room";
-import {GenericActionsType} from "@/app/_lib/actions";
+import {GenericActionsType, withAction} from "@/app/_lib/actions";
 import {number, object} from "zod";
-import {after} from "next/server";
 import {serverLogger} from "@/app/_lib/axiom/server";
 import {serializeForClient} from "@/app/_lib/util/prisma";
 
 const toClient = <T>(value: T) => serializeForClient(value);
 
-export async function upsertRoomAction(roomData: Partial<RoomsWithTypeAndLocation>): Promise<GenericActionsType<RoomsWithTypeAndLocation>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const upsertRoomAction = withAction(async (roomData: Partial<RoomsWithTypeAndLocation>): Promise<GenericActionsType<RoomsWithTypeAndLocation>> => {
     const {success, data, error} = roomWithType.safeParse(roomData);
 
     if (!success) {
@@ -53,16 +49,13 @@ export async function upsertRoomAction(roomData: Partial<RoomsWithTypeAndLocatio
 
         return toClient({failure: "Request unsuccessful"});
     }
-}
+});
 
 export async function getRoomsWithBookingsAction(locationID?: number, limit?: number, offset?: number) {
     return getRoomsWithBookings(undefined, locationID, limit, offset).then(toClient);
 }
 
-export async function deleteRoomAction(id: string): Promise<GenericActionsType<RoomsWithTypeAndLocation>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deleteRoomAction = withAction(async (id: string): Promise<GenericActionsType<RoomsWithTypeAndLocation>> => {
     const parsedData = object({id: number().positive()}).safeParse({
         id: id,
     });
@@ -84,4 +77,4 @@ export async function deleteRoomAction(id: string): Promise<GenericActionsType<R
             failure: "Error deleting guest",
         });
     }
-}
+});

--- a/src/app/(internal)/(dashboard_layout)/rooms/types/room-type-actions.ts
+++ b/src/app/(internal)/(dashboard_layout)/rooms/types/room-type-actions.ts
@@ -3,19 +3,15 @@
 import {RoomType} from "@prisma/client";
 import {PrismaClientKnownRequestError, PrismaClientUnknownRequestError} from "@prisma/client/runtime/library";
 import {createRoomType, deleteRoomType, updateRoomTypeByID} from "@/app/_db/room";
-import {GenericActionsType} from "@/app/_lib/actions";
+import {GenericActionsType, withAction} from "@/app/_lib/actions";
 import {number, object} from "zod";
 import {roomTypeSchemaWithOptionalID} from "@/app/_lib/zod/rooms/roomtypes";
-import {after} from "next/server";
 import {serverLogger} from "@/app/_lib/axiom/server";
 import {serializeForClient} from "@/app/_lib/util/prisma";
 
 const toClient = <T>(value: T) => serializeForClient(value);
 
-export async function upsertRoomTypeAction(roomData: Partial<RoomType>): Promise<GenericActionsType<RoomType>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const upsertRoomTypeAction = withAction(async (roomData: Partial<RoomType>): Promise<GenericActionsType<RoomType>> => {
     const {success, data, error} = roomTypeSchemaWithOptionalID.safeParse(roomData);
 
     if (!success) {
@@ -52,12 +48,9 @@ export async function upsertRoomTypeAction(roomData: Partial<RoomType>): Promise
 
         return toClient({failure: "Request unsuccessful"});
     }
-}
+});
 
-export async function deleteRoomTypeAction(id: string): Promise<GenericActionsType<RoomType>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deleteRoomTypeAction = withAction(async (id: string): Promise<GenericActionsType<RoomType>> => {
     const parsedData = object({id: number().positive()}).safeParse({
         id: id,
     });
@@ -86,4 +79,4 @@ export async function deleteRoomTypeAction(id: string): Promise<GenericActionsTy
 
         return toClient({failure: "Request unsuccessful"});
     }
-}
+});

--- a/src/app/(internal)/(dashboard_layout)/s3/[[...s3Path]]/route.ts
+++ b/src/app/(internal)/(dashboard_layout)/s3/[[...s3Path]]/route.ts
@@ -1,12 +1,9 @@
-import {after, NextResponse} from "next/server";
+import {NextResponse} from "next/server";
 import * as process from "node:process";
 import {getObject} from "@/app/_lib/s3";
 import {serverLogger, withAxiom} from "@/app/_lib/axiom/server";
 
 export const GET = withAxiom(async (request: Request, props: { params: Promise<{ s3Path: string[] }> }) => {
-    after(() => {
-        serverLogger.flush();
-    });
 
     const params = await props.params;
     const fullPath = params.s3Path.join('/');

--- a/src/app/(internal)/(dashboard_layout)/schedule/calendar/calendar-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/schedule/calendar/calendar-action.ts
@@ -4,8 +4,7 @@ import {EventApi} from "@fullcalendar/core";
 import prisma from "@/app/_lib/primsa";
 import {CalenderEventTypes, CheckInOutType} from "@/app/(internal)/(dashboard_layout)/bookings/enum";
 import {Event} from "@prisma/client";
-import {GenericActionsType} from "@/app/_lib/actions";
-import {after} from "next/server";
+import {GenericActionsType, withAction} from "@/app/_lib/actions";
 import {serverLogger} from "@/app/_lib/axiom/server";
 import {serializeForClient} from "@/app/_lib/util/prisma";
 
@@ -144,10 +143,7 @@ export async function getCalendarEvents(locationID?: number, dateRange?: Calende
     return toClient(events);
 }
 
-export async function deleteCalendarEvent(id: number): Promise<GenericActionsType<boolean>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deleteCalendarEvent = withAction(async (id: number): Promise<GenericActionsType<boolean>> => {
     try {
         await prisma.event.delete({
             where: {
@@ -164,4 +160,4 @@ export async function deleteCalendarEvent(id: number): Promise<GenericActionsTyp
     return toClient({
         success: true,
     });
-}
+});

--- a/src/app/(internal)/(dashboard_layout)/schedule/create/event-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/schedule/create/event-action.ts
@@ -5,17 +5,13 @@ import {Event, Prisma} from "@prisma/client";
 import {eventSchemaWithOptionalID} from "@/app/_lib/zod/event/zod";
 import {PrismaClientKnownRequestError} from "@prisma/client/runtime/library";
 import {createEvent, updateEventByID} from "@/app/_db/event";
-import {GenericActionsType} from "@/app/_lib/actions";
-import {after} from "next/server";
+import {GenericActionsType, withAction} from "@/app/_lib/actions";
 import {serverLogger} from "@/app/_lib/axiom/server";
 import {serializeForClient} from "@/app/_lib/util/prisma";
 
 const toClient = <T>(value: T) => serializeForClient(value);
 
-export async function upsertEventAction(reqData: OmitIDTypeAndTimestamp<Event>): Promise<GenericActionsType<Event>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const upsertEventAction = withAction(async (reqData: OmitIDTypeAndTimestamp<Event>): Promise<GenericActionsType<Event>> => {
     const {success, data, error} = eventSchemaWithOptionalID.safeParse(reqData);
 
     if (!success) {
@@ -66,4 +62,4 @@ export async function upsertEventAction(reqData: OmitIDTypeAndTimestamp<Event>):
     return toClient({
         success: res
     });
-}
+});

--- a/src/app/(internal)/(dashboard_layout)/settings/users/site_users-action.ts
+++ b/src/app/(internal)/(dashboard_layout)/settings/users/site_users-action.ts
@@ -5,20 +5,16 @@ import {PrismaClientKnownRequestError, PrismaClientUnknownRequestError} from "@p
 import {siteUserSchemaWithOptionalID} from "@/app/_lib/zod/user/zod";
 import {createUser, deleteUser, getUserByID, updateUser} from "@/app/_db/user";
 import {auth} from "@/app/_lib/auth";
-import {GenericActionsType} from "@/app/_lib/actions";
+import {GenericActionsType, withAction} from "@/app/_lib/actions";
 import {object, string} from "zod";
 import bcrypt from "bcrypt";
-import {after} from "next/server";
 import {serverLogger} from "@/app/_lib/axiom/server";
 import {serializeForClient} from "@/app/_lib/util/prisma";
 
 const toClient = <T>(value: T) => serializeForClient(value);
 
 // Action to update site users
-export async function upsertSiteUserAction(userData: Partial<SiteUser>): Promise<GenericActionsType<SiteUser>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const upsertSiteUserAction = withAction(async (userData: Partial<SiteUser>): Promise<GenericActionsType<SiteUser>> => {
     const session = await auth();
 
     if (session && session.user) {
@@ -74,12 +70,9 @@ export async function upsertSiteUserAction(userData: Partial<SiteUser>): Promise
 
         return toClient({failure: "Update unsuccessful"});
     }
-}
+});
 
-export async function deleteUserAction(id: string): Promise<GenericActionsType<Pick<SiteUser, "id">>> {
-    after(() => {
-        serverLogger.flush();
-    });
+export const deleteUserAction = withAction(async (id: string): Promise<GenericActionsType<Pick<SiteUser, "id">>> => {
     const session = await auth();
 
     if (session && session.user) {
@@ -114,4 +107,4 @@ export async function deleteUserAction(id: string): Promise<GenericActionsType<P
             failure: "error"
         });
     }
-}
+});

--- a/src/app/(internal)/first-time-setup/setup-action.ts
+++ b/src/app/(internal)/first-time-setup/setup-action.ts
@@ -4,7 +4,7 @@ import {z} from "zod";
 import {finalValidationSetupSchema, stepValidationSetupSchema} from "@/app/_lib/zod/setup/zod";
 import prisma from "@/app/_lib/primsa";
 import {SettingsKey} from "@/app/_enum/setting";
-import {after} from "next/server";
+import {withRequestId} from "@/app/_lib/actions";
 import {serverLogger} from "@/app/_lib/axiom/server";
 
 export async function validateStepData(data: Partial<z.infer<typeof stepValidationSetupSchema>>) {
@@ -24,10 +24,7 @@ export async function validateStepData(data: Partial<z.infer<typeof stepValidati
 }
 
 // Example function to validate final form data
-export async function validateFinalData(data: z.infer<typeof finalValidationSetupSchema>) {
-    after(() => {
-        serverLogger.flush();
-    });
+export const validateFinalData = withRequestId(async (data: z.infer<typeof finalValidationSetupSchema>) => {
     try {
         const {success, data: parsedData, error} = finalValidationSetupSchema.safeParse(data);
         if (!success) {
@@ -89,4 +86,4 @@ export async function validateFinalData(data: z.infer<typeof finalValidationSetu
         serverLogger.error("[validateFinalData]", {error});
         return { failure: true };
     }
-}
+});

--- a/src/app/_db/transaction.ts
+++ b/src/app/_db/transaction.ts
@@ -3,7 +3,6 @@
 import {Booking, Prisma, Transaction} from "@prisma/client";
 import {OmitIDTypeAndTimestamp} from "@/app/_db/db";
 import prisma from "@/app/_lib/primsa";
-import {after} from "next/server";
 import {serverLogger} from "@/app/_lib/axiom/server";
 import TransactionFindManyArgs = Prisma.TransactionFindManyArgs;
 
@@ -19,9 +18,6 @@ export async function getTransactions(args: TransactionFindManyArgs) {
 }
 
 export async function getTransactionsWithBookingInfo(args: TransactionFindManyArgs): Promise<TransactionWithBookingInfo[]> {
-    after(() => {
-        serverLogger.flush();
-    });
     // First get the basic transactions
     const transactions = await prisma.transaction.findMany(args);
 

--- a/src/app/_lib/actions.ts
+++ b/src/app/_lib/actions.ts
@@ -1,7 +1,60 @@
 import {ZodFormattedError} from "zod";
+import {headers} from "next/headers";
+import {after} from "next/server";
+import {requestIdStorage, getRequestId} from "@/app/_lib/request-context";
+import {serverLogger} from "@/app/_lib/axiom/server";
 
 export type GenericActionsType<T> = {
   success?: T | null,
   failure?: string,
-  errors?: ZodFormattedError<any>
+  errors?: ZodFormattedError<any>,
+  requestId?: string,
 }
+
+/**
+ * Wraps a server action that returns GenericActionsType.
+ * - Sets up request ID context (AsyncLocalStorage) for automatic log enrichment
+ * - Schedules serverLogger.flush() via after()
+ * - Attaches requestId to failure/error responses automatically
+ */
+export function withAction<TArgs extends unknown[], T>(
+    fn: (...args: TArgs) => Promise<GenericActionsType<T>>
+): (...args: TArgs) => Promise<GenericActionsType<T>> {
+    return async (...args: TArgs): Promise<GenericActionsType<T>> => {
+        const headersList = await headers();
+        const requestId = headersList.get('x-request-id') || crypto.randomUUID();
+
+        return requestIdStorage.run(requestId, async () => {
+            after(() => serverLogger.flush());
+
+            const result = await fn(...args);
+
+            if (result.failure || result.errors) {
+                return {...result, requestId};
+            }
+
+            return result;
+        });
+    };
+}
+
+/**
+ * Wraps a server action that returns arbitrary data (not GenericActionsType).
+ * - Sets up request ID context (AsyncLocalStorage) for automatic log enrichment
+ * - Schedules serverLogger.flush() via after()
+ */
+export function withRequestId<TArgs extends unknown[], TReturn>(
+    fn: (...args: TArgs) => Promise<TReturn>
+): (...args: TArgs) => Promise<TReturn> {
+    return async (...args: TArgs): Promise<TReturn> => {
+        const headersList = await headers();
+        const requestId = headersList.get('x-request-id') || crypto.randomUUID();
+
+        return requestIdStorage.run(requestId, async () => {
+            after(() => serverLogger.flush());
+            return fn(...args);
+        });
+    };
+}
+
+export {getRequestId};

--- a/src/app/_lib/auth.ts
+++ b/src/app/_lib/auth.ts
@@ -8,7 +8,6 @@ import {Provider} from "@auth/core/providers";
 import {signInSchema} from "@/app/_lib/zod/auth/zod";
 import {ZodError} from "zod";
 import bcrypt from "bcrypt";
-import {after} from "next/server";
 import {serverLogger} from "@/app/_lib/axiom/server";
 
 class InvalidCredentialsError extends CredentialsSignin {
@@ -27,9 +26,6 @@ const providers: Provider[] = [
             },
         },
         authorize: async (credentials) => {
-            after(() => {
-                serverLogger.flush();
-            });
             try {
                 let user = null;
 
@@ -96,9 +92,6 @@ export const {handlers, signIn, signOut, auth} = NextAuth({
             return baseUrl;
         },
         async jwt({token, user}) {
-            after(() => {
-                serverLogger.flush();
-            });
             if (user) {
                 token.user = user;
             }

--- a/src/app/_lib/axiom/formatter.ts
+++ b/src/app/_lib/axiom/formatter.ts
@@ -1,4 +1,5 @@
 import type {Formatter} from '@axiomhq/logging';
+import {getRequestId} from '@/app/_lib/request-context';
 
 export const addStaticFields: Formatter = (rec) => ({
     ...rec,
@@ -8,3 +9,15 @@ export const addStaticFields: Formatter = (rec) => ({
         vercel_deployment_id: process.env.VERCEL_DEPLOYMENT_ID,
     },
 });
+
+export const addRequestId: Formatter = (rec) => {
+    const requestId = getRequestId();
+    if (!requestId) return rec;
+    return {
+        ...rec,
+        fields: {
+            ...rec.fields,
+            requestId,
+        },
+    };
+};

--- a/src/app/_lib/axiom/server.ts
+++ b/src/app/_lib/axiom/server.ts
@@ -1,7 +1,9 @@
 import axiomClient from '@/app/_lib/axiom/axiom';
 import {AxiomJSTransport, ConsoleTransport, Logger} from '@axiomhq/logging';
 import {createAxiomRouteHandler, nextJsFormatters} from '@axiomhq/nextjs';
-import {addStaticFields} from "@/app/_lib/axiom/formatter";
+import {addRequestId, addStaticFields} from "@/app/_lib/axiom/formatter";
+import {requestIdStorage} from "@/app/_lib/request-context";
+import type {NextRequest} from "next/server";
 
 const shouldLogToAxiom =
     process.env.NODE_ENV === 'production' &&
@@ -21,7 +23,18 @@ export const serverLogger = new Logger({
         : [new ConsoleTransport({
             prettyPrint: true,
         })],
-    formatters: [...nextJsFormatters, addStaticFields],
+    formatters: [...nextJsFormatters, addStaticFields, addRequestId],
 });
 
-export const withAxiom = createAxiomRouteHandler(serverLogger);
+const _withAxiom = createAxiomRouteHandler(serverLogger);
+
+/**
+ * Wraps a route handler with both Axiom logging and request ID context (ALS).
+ * Use this instead of raw withAxiom for API routes.
+ */
+export function withAxiom(handler: (req: any, ...args: any[]) => Promise<Response>) {
+    return _withAxiom((req: NextRequest | Request, ...args: any[]) => {
+        const requestId = req.headers.get('x-request-id') || crypto.randomUUID();
+        return requestIdStorage.run(requestId, () => handler(req, ...args));
+    });
+}

--- a/src/app/_lib/mailer.ts
+++ b/src/app/_lib/mailer.ts
@@ -5,7 +5,6 @@ import prisma from "@/app/_lib/primsa";
 import {PartialBy} from "@/app/_db/db";
 import * as util from "node:util";
 import {serverLogger} from "@/app/_lib/axiom/server";
-import {after} from "next/server";
 
 enum EmailStatus {
     SUCCESS = "SUCCESS",
@@ -52,9 +51,6 @@ class NodemailerSingleton {
     }
 
     public async sendMail(mailOptions: PartialBy<Options, "from">) {
-        after(() => {
-            serverLogger.flush();
-        });
         mailOptions.from = mailOptions.from ?? NodemailerSingleton.DEFAULT_FROM;
         try {
             const response = await this.client.sendMail(mailOptions);

--- a/src/app/_lib/request-context.ts
+++ b/src/app/_lib/request-context.ts
@@ -1,0 +1,10 @@
+import {AsyncLocalStorage} from 'node:async_hooks';
+
+export const requestIdStorage = new AsyncLocalStorage<string>();
+
+/**
+ * Returns the request ID for the current request context, or undefined if called outside one.
+ */
+export function getRequestId(): string | undefined {
+    return requestIdStorage.getStore();
+}

--- a/src/app/_lib/s3.ts
+++ b/src/app/_lib/s3.ts
@@ -1,6 +1,5 @@
 import {GetObjectCommand, S3Client} from "@aws-sdk/client-s3";
 import {Readable} from 'stream';
-import {after} from "next/server";
 import {serverLogger} from "@/app/_lib/axiom/server";
 
 const client = new S3Client({region: process.env.AWS_REGION});
@@ -18,9 +17,6 @@ export type GetObjectReturnType = {
 }
 
 export async function getObject(bucket: string, key: string): Promise<GetObjectReturnType> {
-    after(() => {
-        serverLogger.flush();
-    });
     const getObjectCommand = new GetObjectCommand({ Bucket: bucket, Key: key });
 
     try {

--- a/src/app/api/(internal)/cron/monthly-billing/route.ts
+++ b/src/app/api/(internal)/cron/monthly-billing/route.ts
@@ -1,4 +1,4 @@
-import {after, NextResponse} from "next/server";
+import {NextResponse} from "next/server";
 import prisma from "@/app/_lib/primsa";
 import {generateNextMonthlyBill} from "@/app/(internal)/(dashboard_layout)/bookings/booking-action";
 import {serverLogger, withAxiom} from "@/app/_lib/axiom/server";
@@ -7,9 +7,6 @@ export const maxDuration = 60;
 export const dynamic = 'force-dynamic';
 
 export const POST = withAxiom(async () => {
-    after(() => {
-        serverLogger.flush();
-    });
     try {
         const activeRollingBookings = await prisma.booking.findMany({
             where: {

--- a/src/app/api/(internal)/debug/email/route.ts
+++ b/src/app/api/(internal)/debug/email/route.ts
@@ -4,12 +4,8 @@ import nodemailerClient from "@/app/_lib/mailer";
 import {emailSchema} from "@/app/_lib/zod/email/zod";
 import {getToken} from "@auth/core/jwt";
 import {serverLogger, withAxiom} from "@/app/_lib/axiom/server";
-import {after} from "next/server";
 
 export const POST = withAxiom(async (request: Request) => {
-    after(() => {
-        serverLogger.flush();
-    });
 
     const token = await getToken({
         req: request,

--- a/src/app/api/(internal)/tasks/email/invoice-reminder/route.ts
+++ b/src/app/api/(internal)/tasks/email/invoice-reminder/route.ts
@@ -4,7 +4,6 @@ import {SettingsKey} from "@/app/_enum/setting";
 import pLimit from "p-limit";
 import {generateBillEmailReminders} from "@/app/api/(internal)/tasks/email/invoice-reminder/invoice-reminder-action";
 import {serverLogger, withAxiom} from "@/app/_lib/axiom/server";
-import {after} from "next/server";
 
 export const maxDuration = 60;
 export const dynamic = 'force-dynamic';
@@ -17,10 +16,6 @@ export const GET = withAxiom(async (request: Request) => {
             status: 401,
         });
     }
-
-    after(() => {
-        serverLogger.flush();
-    });
 
     let emailReminderEnabled = await prisma.setting.findFirst({
         where: {

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,2 +1,5 @@
 import { handlers } from "@/app/_lib/auth";
-export const { GET, POST } = handlers;
+import { withAxiom } from "@/app/_lib/axiom/server";
+
+export const GET = withAxiom(handlers.GET);
+export const POST = withAxiom(handlers.POST);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,21 +4,31 @@ import {NextResponse} from "next/server";
 import {serverLogger} from "@/app/_lib/axiom/server";
 
 export async function middleware(request: NextRequest, event: NextFetchEvent) {
+    const requestId = crypto.randomUUID();
+
+    const requestHeaders = new Headers(request.headers);
+    requestHeaders.set('x-request-id', requestId);
+
     serverLogger.info(...transformMiddlewareRequest(request));
 
     event.waitUntil(serverLogger.flush());
-    return NextResponse.next();
+
+    const response = NextResponse.next({
+        request: {headers: requestHeaders},
+    });
+    response.headers.set('x-request-id', requestId);
+
+    return response;
 }
 
 export const config = {
     matcher: [
         /*
          * Match all request paths except for the ones starting with:
-         * - api (API routes)
          * - _next/static (static files)
          * - _next/image (image optimization files)
          * - favicon.ico, sitemap.xml, robots.txt (metadata files)
          */
-        "/((?!api|_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
+        "/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt).*)",
     ],
 };


### PR DESCRIPTION
Introduces AsyncLocalStorage-based request ID propagation so every log entry is automatically enriched with a correlating request ID, enabling end-to-end request tracing in Axiom.

- Add request-context.ts with AsyncLocalStorage for request IDs
- Add withAction/withRequestId wrappers that set up ALS context and auto-flush the logger via after()
- Generate x-request-id in middleware, forward in request/response headers
- Add addRequestId Axiom formatter to attach ID to all log records
- Wrap auth route with withAxiom for request ID context in NextAuth callbacks
- Migrate all server actions to use wrappers, removing manual after() flush
- Remove redundant flush calls from utility functions and route handlers already wrapped with withAxiom